### PR TITLE
 Take into account padding and margins on content

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -51,8 +51,8 @@
         var updateBarSizeAndPosition = function() {
             container_width = $this.width();
             container_height = $this.height();
-            content_width = $content.width();
-            content_height = $content.height();
+            content_width = $content.outerWidth(true);
+            content_height = $content.outerHeight(true);
             if(container_width < content_width) {
                 scrollbar_x_width = parseInt(container_width * container_width / content_width);
                 scrollbar_x_left = parseInt($this.scrollLeft() * container_width / content_width);


### PR DESCRIPTION
Changed the height and widths calculations of the content div to
include any padding and/or margins.

There is also some strange behaviour when the container has padding and or margins, which I am still looking into. 
