### PR TITLE
Fixed bug with the Mouse Wheel and the right scroll bar.

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -90,6 +90,10 @@
                 $this.scrollTop(0);
             }
 
+            if(scrollbar_y_top >= container_height - scrollbar_y_height) {
+                scrollbar_y_top = container_height - scrollbar_y_height;
+            }
+
             $scrollbar_x.css({left: scrollbar_x_left + $this.scrollLeft(), bottom: scrollbar_x_bottom - $this.scrollTop(), width: scrollbar_x_width});
             $scrollbar_y.css({top: scrollbar_y_top + $this.scrollTop(), right: scrollbar_y_right - $this.scrollLeft(), height: scrollbar_y_height});
         };


### PR DESCRIPTION
When a content has tags inside, like paragraphs, there is a bug with the scroll bar and the mouse wheel. 

When scrolling, the bar doesn't stop at the bottom of the content layer; it continues to fall infinitely. 

With this fix, the behaviour of the right bar is now perfect.
