### PR TITLE
Fixed some bug in xp sp3 ie7 & ie6 and add an example

### DIFF
--- a/examples/text-content.html
+++ b/examples/text-content.html
@@ -6,9 +6,9 @@
         <title>Ul-content</title>
         <link href="../src/perfect-scrollbar.css" rel="stylesheet">
         <script type="text/javascript" src="https://getfirebug.com/firebug-lite-debug.js"></script>
-        <script src="http://code.jquery.com/jquery-1.10.0.js"></script>
-        <script src="../src/jquery.mousewheel.js"></script>
-        <script src="../src/perfect-scrollbar.js"></script>
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js" type="text/javascript"></script>
+        <script src="../src/jquery.mousewheel.js" type="text/javascript"></script>
+        <script src="../src/perfect-scrollbar.js" type="text/javascript"></script>
         <style>
             #description {
                 border: 1px solid gray;

--- a/examples/text-content.html
+++ b/examples/text-content.html
@@ -1,0 +1,47 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    
+        <title>Ul-content</title>
+        <link href="../src/perfect-scrollbar.css" rel="stylesheet">
+        <script type="text/javascript" src="https://getfirebug.com/firebug-lite-debug.js"></script>
+        <script src="http://code.jquery.com/jquery-1.10.0.js"></script>
+        <script src="../src/jquery.mousewheel.js"></script>
+        <script src="../src/perfect-scrollbar.js"></script>
+        <style>
+            #description {
+                border: 1px solid gray;
+                height:150px;
+                width: 400px;
+                overflow: hidden;
+                position: absolute;
+            }
+        </style>
+        <script type="text/javascript">
+            debugger;
+          $(document).ready(function ($) {
+              $('#description').perfectScrollbar({
+                  wheelSpeed: 20,
+                  wheelPropagation: false
+              });
+          });
+        </script>
+    </head>
+    <body>
+        <div id="description" class="wrapper">
+            <div>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+                <p>The command takes options applicable</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/examples/ul-content.html
+++ b/examples/ul-content.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    
+        <title>Ul-content</title>
+        
+    </head>
+    <body>
+        
+    </body>
+</html>

--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -8,6 +8,7 @@
     position: absolute; /* please don't change 'position' */
     bottom: 3px; /* there must be 'bottom' for ps-scrollbar-x */
     height: 8px;
+    font-size: 0; /* fixed scrollbar height in xp sp3 ie6 */
     background-color: #aaa;
     border-radius: 4px;
     -webkit-border-radius: 4px;
@@ -41,6 +42,7 @@
     position: absolute; /* please don't change 'position' */
     right: 3px; /* there must be 'right' for ps-scrollbar-y */
     width: 8px;
+    font-size: 0;/* fixed scrollbar height in xp sp3 ie6 */
     background-color: #aaa;
     border-radius: 4px;
     -webkit-border-radius: 4px;

--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -7,6 +7,7 @@
 .ps-container .ps-scrollbar-x {
     position: absolute; /* please don't change 'position' */
     bottom: 3px; /* there must be 'bottom' for ps-scrollbar-x */
+    _bottom: 3px !important; /* fixed ie6 */
     height: 8px;
     font-size: 0; /* fixed scrollbar height in xp sp3 ie6 */
     background-color: #aaa;
@@ -41,6 +42,7 @@
 .ps-container .ps-scrollbar-y {
     position: absolute; /* please don't change 'position' */
     right: 3px; /* there must be 'right' for ps-scrollbar-y */
+    _right: 3px !important; /* fixed ie6 */
     width: 8px;
     font-size: 0;/* fixed scrollbar height in xp sp3 ie6 */
     background-color: #aaa;

--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -1,3 +1,6 @@
+.ps-container, x:ie {
+    background-image: url('_blank');/*This will introduce an extra connection. */
+}
 .ps-container .ps-scrollbar-x {
     position: absolute; /* please don't change 'position' */
     bottom: 3px; /* there must be 'bottom' for ps-scrollbar-x */

--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -1,8 +1,13 @@
-.ps-container, x:ie {
-    background-image: url('_blank');/*This will introduce an extra connection. */
+@media screen and (min-width:0\0) {  
+    .ps-container {
+        background-image: url('about:blank');/*fixed ie9 ie10 and no extra connection introduced. */
+    }
+}
+.ps-container {
+    background-image: url('about:blank')\9;/*fixed ie6 ie7 ie8 and no extra connection introduced. */
 }
 .ps-container > *, x:ie {
-    zoom: 1;
+    zoom: 1; /* fixed hasLayout problem in ie7 */
 }
 .ps-container .ps-scrollbar-x {
     position: absolute; /* please don't change 'position' */

--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -1,6 +1,9 @@
 .ps-container, x:ie {
     background-image: url('_blank');/*This will introduce an extra connection. */
 }
+.ps-container > *, x:ie {
+    zoom: 1;
+}
 .ps-container .ps-scrollbar-x {
     position: absolute; /* please don't change 'position' */
     bottom: 3px; /* there must be 'bottom' for ps-scrollbar-x */

--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -19,12 +19,14 @@
     transition: opacity .2s linear;
 }
 
-.ps-container:hover .ps-scrollbar-x {
+.ps-container:hover .ps-scrollbar-x,
+.ps-container.hover .ps-scrollbar-x {
     opacity: 0.6;
     filter: alpha(opacity = 60);
 }
 
-.ps-container .ps-scrollbar-x:hover {
+.ps-container .ps-scrollbar-x:hover,
+.ps-container .ps-scrollbar-x.hover {
     opacity: 0.9;
     filter: alpha(opacity = 90);
     cursor:default;
@@ -50,12 +52,14 @@
     transition: opacity .2s linear;
 }
 
-.ps-container:hover .ps-scrollbar-y {
+.ps-container:hover .ps-scrollbar-y,
+.ps-container.hover .ps-scrollbar-y {
     opacity: 0.6;
     filter: alpha(opacity = 60);
 }
 
-.ps-container .ps-scrollbar-y:hover {
+.ps-container .ps-scrollbar-y:hover ,
+.ps-container .ps-scrollbar-y.hover {
     opacity: 0.9;
     filter: alpha(opacity = 90);
     cursor: default;

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -2,7 +2,7 @@
  * Licensed under the MIT License
  */
 ((function ($) {
-
+  
   // The default settings for the plugin
   var defaultSettings = {
     wheelSpeed: 10,
@@ -296,12 +296,30 @@
         $this.data('perfect-scrollbar-destroy', null);
       };
 
+      var pseudoClass = function () {
+          var mouseenter = function () { 
+              $(this).addClass('hover');
+          };
+          var mouseleave = function () {
+              $(this).removeClass('hover');
+          };
+          $this.bind('mouseenter.perfect-scroll', mouseenter)
+              .bind('mouseleave.perfect-scroll', mouseleave);
+          $scrollbarX.bind('mouseenter.perfect-scroll', mouseenter)
+              .bind('mouseleave.perfect-scroll', mouseleave);
+          $scrollbarY.bind('mouseenter.perfect-scroll', mouseenter)
+              .bind('mouseleave.perfect-scroll', mouseleave);
+      };
+
       var isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
 
       var initialize = function () {
         updateBarSizeAndPosition();
         bindMouseScrollXHandler();
         bindMouseScrollYHandler();
+        if ($.browser.msie && $.browser.version == '6.0') {
+            pseudoClass();
+        }
         if (isMobile) {
           bindMobileTouchHandler();
         }

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -317,7 +317,8 @@
         updateBarSizeAndPosition();
         bindMouseScrollXHandler();
         bindMouseScrollYHandler();
-        if ($.browser.msie && $.browser.version == '6.0') {
+        var ieMatch = navigator.userAgent.toLowerCase().match(/(msie) ([\w.]+)/);
+        if (ieMatch && ieMatch[1] == 'msie' && ieMatch[2] == '6.0') {
             pseudoClass();
         }
         if (isMobile) {


### PR DESCRIPTION
1. fixed mouse scroll over blank area bug.
2. fixed contentHeight and contentWidth retrieve.
3. add an examples based on text content.
4. fixed the unsupported ':hover' pseudo-class  in ie6.
5. fixed the position of scrollbar when scroll in ie6.
6. fixed the size of scrollbar in ie6
