### PR TITLE
use scrollHeight & scrollWidth to avoid getting the wrong size of the content

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -70,8 +70,8 @@
       var updateBarSizeAndPosition = function () {
         containerWidth = $this.width();
         containerHeight = $this.height();
-        contentWidth = $content.outerWidth(false);
-        contentHeight = $content.outerHeight(false);
+        contentWidth = $this.prop('scrollWidth');
+        contentHeight = $this.prop('scrollHeight');
         if (containerWidth < contentWidth) {
           scrollbarXWidth = parseInt(containerWidth * containerWidth / contentWidth, 10);
           scrollbarXLeft = parseInt($this.scrollLeft() * containerWidth / contentWidth, 10);


### PR DESCRIPTION
use $this[0].scrollHeight & $this[0].scrollWidth to avoid getting the wrong size of the content
