### PR TITLE
Adding min and max yHeight/xWidth options for scroll bar handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,8 @@ Default: 10
 If this option is true, when the scroll reach the end of the side, mousewheel event will be propagated to parent element.  
 Default: false
 
-### minThumbSize
+### minScrollbarLength
 When set to an integer value, the thumb part of the scrollbar will not shrink below that number of pixels
-Default: null
-
-### maxThumbSize
-When set to an integer value, the thumb part of the scrollbar will never be larger than that number of pixels
 Default: null
 
 How to Use
@@ -90,9 +86,8 @@ With optional parameters:
 $("#Demo").perfectScrollbar({
   wheelSpeed: 20,
   wheelPropagation: true,
-  minThumbSize: 20,
-  maxThumbSize: 100
-})
+  minScrollbarLength: 20,
+});
 ```
 
 If the size of your container or content changes:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Default: 10
 If this option is true, when the scroll reach the end of the side, mousewheel event will be propagated to parent element.  
 Default: false
 
+### minThumbSize
+When set to an integer value, the thumb part of the scrollbar will not shrink below that number of pixels
+Default: null
+
+### maxThumbSize
+When set to an integer value, the thumb part of the scrollbar will never be larger than that number of pixels
+Default: null
 
 How to Use
 ----------
@@ -82,7 +89,9 @@ With optional parameters:
 ```javascript
 $("#Demo").perfectScrollbar({
   wheelSpeed: 20,
-  wheelPropagation: true
+  wheelPropagation: true,
+  minThumbSize: 20,
+  maxThumbSize: 100
 })
 ```
 

--- a/examples/options-minScrollbarLength.html
+++ b/examples/options-minScrollbarLength.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>perfect-scrollbar example - use wheelSpeed to change speed of scrolling</title>
+        <link href="../src/perfect-scrollbar.css" rel="stylesheet">
+        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.8.0/jquery.min.js"></script>
+        <script src="../src/jquery.mousewheel.js"></script>
+        <script src="../src/perfect-scrollbar.js"></script>
+        <style>
+          .contentHolder { position:relative; margin:0px auto; padding:0px; width: 640px; height: 360px; overflow: hidden; }
+          .contentHolder .content { background-image: url('./azusa.jpg'); width: 12800px; height: 7200px; }
+          .spacer { text-align:center }
+        </style>
+    <script>
+      jQuery(document).ready(function ($) {
+        "use strict";
+        $('#Default').perfectScrollbar();
+        $('#LongThumb').perfectScrollbar({minScrollbarLength:100});
+      });
+    </script>
+  </head>
+  <body>
+    <h1 style="text-align:center">No minium</h1>
+    <div id="Default" class="contentHolder">
+      <div class="content">
+      </div>
+    </div>
+    <h1 style="text-align:center">100px minimum</h1>
+    <div id="LongThumb" class="contentHolder">
+      <div class="content">
+      </div>
+    </div>
+  </body>
+</html>
+

--- a/examples/options-minScrollbarLength.html
+++ b/examples/options-minScrollbarLength.html
@@ -21,7 +21,7 @@
     </script>
   </head>
   <body>
-    <h1 style="text-align:center">No minium</h1>
+    <h1 style="text-align:center">No minimum</h1>
     <div id="Default" class="contentHolder">
       <div class="content">
       </div>

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -69,8 +69,8 @@
       };
 
       var getSettingsAdjustedThumbSize = function (thumbSize) {
-        if (settings.minScrollbarSize) {
-          thumbSize = Math.max(thumbSize, settings.minScrollbarSize);
+        if (settings.minScrollbarLength) {
+          thumbSize = Math.max(thumbSize, settings.minScrollbarLength);
         }
         return thumbSize;
       };

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -7,8 +7,7 @@
   var defaultSettings = {
     wheelSpeed: 10,
     wheelPropagation: false,
-    minThumbSize: null,
-    maxThumbSize: null
+    minScrollbarLength: null,
   };
 
   $.fn.perfectScrollbar = function (suppliedSettings, option) {
@@ -70,14 +69,11 @@
       };
 
       var getSettingsAdjustedThumbSize = function (thumbSize) {
-        if (settings.minThumbSize) {
-          thumbSize = Math.max(thumbSize, settings.minThumbSize);
-        }
-        if (settings.maxThumbSize) {
-          thumbSize = Math.min(thumbSize, settings.maxThumbSize);
+        if (settings.minScrollbarSize) {
+          thumbSize = Math.max(thumbSize, settings.minScrollbarSize);
         }
         return thumbSize;
-      }
+      };
 
       var updateBarSizeAndPosition = function () {
         containerWidth = $this.width();
@@ -188,8 +184,8 @@
 
         $(document).bind('mousemove.perfect-scroll', function (e) {
           if ($scrollbarY.hasClass('in-scrolling')) {
-             updateContentScrollTop();
-             moveBarY(currentTop, e.pageY - currentPageY);
+            updateContentScrollTop();
+            moveBarY(currentTop, e.pageY - currentPageY);
             e.stopPropagation();
             e.preventDefault();
           }

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -6,7 +6,9 @@
   // The default settings for the plugin
   var defaultSettings = {
     wheelSpeed: 10,
-    wheelPropagation: false
+    wheelPropagation: false,
+    minThumbSize: null,
+    maxThumbSize: null
   };
 
   $.fn.perfectScrollbar = function (suppliedSettings, option) {
@@ -67,13 +69,23 @@
         $scrollbarY.css({right: scrollbarYRight - scrollLeft});
       };
 
+      var getSettingsAdjustedThumbSize = function (thumbSize) {
+        if (settings.minThumbSize) {
+          thumbSize = Math.max(thumbSize, settings.minThumbSize);
+        }
+        if (settings.maxThumbSize) {
+          thumbSize = Math.min(thumbSize, settings.maxThumbSize);
+        }
+        return thumbSize;
+      }
+
       var updateBarSizeAndPosition = function () {
         containerWidth = $this.width();
         containerHeight = $this.height();
         contentWidth = $content.outerWidth(false);
         contentHeight = $content.outerHeight(false);
         if (containerWidth < contentWidth) {
-          scrollbarXWidth = parseInt(containerWidth * containerWidth / contentWidth, 10);
+          scrollbarXWidth = getSettingsAdjustedThumbSize(parseInt(containerWidth * containerWidth / contentWidth, 10));
           scrollbarXLeft = parseInt($this.scrollLeft() * containerWidth / contentWidth, 10);
         }
         else {
@@ -82,7 +94,7 @@
           $this.scrollLeft(0);
         }
         if (containerHeight < contentHeight) {
-          scrollbarYHeight = parseInt(containerHeight * containerHeight / contentHeight, 10);
+          scrollbarYHeight = getSettingsAdjustedThumbSize(parseInt(containerHeight * containerHeight / contentHeight, 10));
           scrollbarYTop = parseInt($this.scrollTop() * containerHeight / contentHeight, 10);
         }
         else {
@@ -176,8 +188,8 @@
 
         $(document).bind('mousemove.perfect-scroll', function (e) {
           if ($scrollbarY.hasClass('in-scrolling')) {
-            updateContentScrollTop();
-            moveBarY(currentTop, e.pageY - currentPageY);
+             updateContentScrollTop();
+             moveBarY(currentTop, e.pageY - currentPageY);
             e.stopPropagation();
             e.preventDefault();
           }


### PR DESCRIPTION
This is a feature addition not a bug, so I will not be offended if you don't want to use it.  I found that it was kind of frustrating when navigating across a long list of items to have the thumb of the scrollbar keep shrinking down to only a few pixels.

I updated the readme to include documentation for the options.  I could definitely see adding some defaults for this but I didn't want to break any existing functionality so I did not add them myself.

(Also I had no idea what the part was called - saw it called "thumb" here:  http://my.safaribooksonline.com/book/programming/microsoft-wpf/9780768695519/advanced-scrolling/ch07lev1sec1)
