### PR TITLE
Hide scrollbar when the container size is equal or smaller to the content's

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -161,6 +161,8 @@
           scrollbarXWidth = 0;
           scrollbarXLeft = 0;
           $this.scrollLeft(0);
+          
+          settings.suppressScrollX = true;
         }
 
         if (!settings.suppressScrollY && containerHeight + settings.scrollYMarginOffset < contentHeight) {
@@ -173,6 +175,8 @@
           scrollbarYHeight = 0;
           scrollbarYTop = 0;
           $this.scrollTop(0);
+          
+          settings.suppressScrollY = true;
         }
 
         if (scrollbarYTop >= containerHeight - scrollbarYHeight) {


### PR DESCRIPTION
Fix #71
