### PR TITLE
Don't scroll by keyevent while form element has focus

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -327,7 +327,7 @@
 
         var shouldPrevent = false;
         $(document).bind('keydown' + eventClassName, function (e) {
-          if (!hovered) {
+          if (!hovered || $(document.activeElement).is(":input,[contenteditable]")) {
             return;
           }
 


### PR DESCRIPTION
Prevent scrolling when keypress event happens inside a form element (input, textarea). Currently perfectScrollbar scrolls the page when a space is entered in an input and prevents the event. This small fix solves this problem.
