### PR TITLE
Overflow:hidden is a required css style

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Why perfect-scrollbar?
 
 I worked on the personal project recently, and I was trying to find the jQuery scrollbar plugin that's *perfect*. But there was no *perfect* scrollbar plugin. That's why I decided to make one.
 
-perfect-scrollbar is very tiny but *perfect*(for me, and maybe for the most of developers) jQuery scrollbar plugin.  
+perfect-scrollbar is very tiny but *perfect*(for me, and maybe for the most of developers) jQuery scrollbar plugin.
 I hope you love this!
 
 Demo: http://noraesae.github.com/perfect-scrollbar/
@@ -42,52 +42,53 @@ Requirements
 To make this plugin *perfect*, some requirements were not avoidable. But they're all very trivial and there's nothing to worry about.
 
 * the container must have a 'position' css style.
+* the container must have an 'overflow:hidden' css style.
 * the scrollbar's position must be 'absolute'.
 * the scrollbar-x must have a 'bottom' css style, and the scrollbar-y must have a 'right' css style.
 
 The requirement below is for perfect-scrollbar &lt;= 0.3.4
 
 * there must be the *one* content element(like div) for the container.
- 
+
 Optional parameters
 -------------------
 
 perfect-scrollbar supports optional parameters.
 
 ### wheelSpeed
-The scroll speed applied to mousewheel event.  
+The scroll speed applied to mousewheel event.
 **Default: 10**
 
 ### wheelPropagation
-If this option is true, when the scroll reach the end of the side, mousewheel event will be propagated to parent element.  
+If this option is true, when the scroll reach the end of the side, mousewheel event will be propagated to parent element.
 **Default: false**
 
 ### minScrollbarLength
-When set to an integer value, the thumb part of the scrollbar will not shrink below that number of pixels.  
+When set to an integer value, the thumb part of the scrollbar will not shrink below that number of pixels.
 **Default: null**
 
 ### useBothWheelAxes
-When set to true, and only one (vertical or horizontal) scrollbar is visible then both vertical and horizontal scrolling will affect the scrollbar.  
+When set to true, and only one (vertical or horizontal) scrollbar is visible then both vertical and horizontal scrolling will affect the scrollbar.
 **Default: false**
 
 ### useKeyboard
-When set to true, the scroll works with arrow keys on the keyboard. The element is scrolled only when the mouse cursor hovers the element.  
+When set to true, the scroll works with arrow keys on the keyboard. The element is scrolled only when the mouse cursor hovers the element.
 **Default: true**
 
 ### suppressScrollX
-When set to true, the scroll bar in X axis will not be available, regardless of the content width.  
+When set to true, the scroll bar in X axis will not be available, regardless of the content width.
 **Default: false**
 
 ### suppressScrollY
-When set to true, the scroll bar in Y axis will not be available, regardless of the content height.  
+When set to true, the scroll bar in Y axis will not be available, regardless of the content height.
 **Default: false**
 
 ### scrollXMarginOffset
-The number of pixels the content width can surpass the container width without enabling the X axis scroll bar. Allows some "wiggle room" or "offset break", so that X axis scroll bar is not enabled just because of a few pixels.  
+The number of pixels the content width can surpass the container width without enabling the X axis scroll bar. Allows some "wiggle room" or "offset break", so that X axis scroll bar is not enabled just because of a few pixels.
 **Default: 0**
 
 ### scrollYMarginOffset
-The number of pixels the content height can surpass the container height without enabling the Y axis scroll bar. Allows some "wiggle room" or "offset break", so that Y axis scroll bar is not enabled just because of a few pixels.  
+The number of pixels the content height can surpass the container height without enabling the Y axis scroll bar. Allows some "wiggle room" or "offset break", so that Y axis scroll bar is not enabled just because of a few pixels.
 **Default: 0**
 
 How to Use
@@ -182,5 +183,5 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 Helpdesk
 --------
 
-If you have any idea to improve this project or any problems using this, please feel free to contact me.  
+If you have any idea to improve this project or any problems using this, please feel free to contact me.
 Email: noraesae@yuiazu.net

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Why perfect-scrollbar?
 
 I worked on the personal project recently, and I was trying to find the jQuery scrollbar plugin that's *perfect*. But there was no *perfect* scrollbar plugin. That's why I decided to make one.
 
-perfect-scrollbar is very tiny but *perfect*(for me, and maybe for the most of developers) jQuery scrollbar plugin.
+perfect-scrollbar is very tiny but *perfect*(for me, and maybe for the most of developers) jQuery scrollbar plugin.  
 I hope you love this!
 
 Demo: http://noraesae.github.com/perfect-scrollbar/
@@ -49,46 +49,46 @@ To make this plugin *perfect*, some requirements were not avoidable. But they're
 The requirement below is for perfect-scrollbar &lt;= 0.3.4
 
 * there must be the *one* content element(like div) for the container.
-
+ 
 Optional parameters
 -------------------
 
 perfect-scrollbar supports optional parameters.
 
 ### wheelSpeed
-The scroll speed applied to mousewheel event.
+The scroll speed applied to mousewheel event.  
 **Default: 10**
 
 ### wheelPropagation
-If this option is true, when the scroll reach the end of the side, mousewheel event will be propagated to parent element.
+If this option is true, when the scroll reach the end of the side, mousewheel event will be propagated to parent element.  
 **Default: false**
 
 ### minScrollbarLength
-When set to an integer value, the thumb part of the scrollbar will not shrink below that number of pixels.
+When set to an integer value, the thumb part of the scrollbar will not shrink below that number of pixels.  
 **Default: null**
 
 ### useBothWheelAxes
-When set to true, and only one (vertical or horizontal) scrollbar is visible then both vertical and horizontal scrolling will affect the scrollbar.
+When set to true, and only one (vertical or horizontal) scrollbar is visible then both vertical and horizontal scrolling will affect the scrollbar.  
 **Default: false**
 
 ### useKeyboard
-When set to true, the scroll works with arrow keys on the keyboard. The element is scrolled only when the mouse cursor hovers the element.
+When set to true, the scroll works with arrow keys on the keyboard. The element is scrolled only when the mouse cursor hovers the element.  
 **Default: true**
 
 ### suppressScrollX
-When set to true, the scroll bar in X axis will not be available, regardless of the content width.
+When set to true, the scroll bar in X axis will not be available, regardless of the content width.  
 **Default: false**
 
 ### suppressScrollY
-When set to true, the scroll bar in Y axis will not be available, regardless of the content height.
+When set to true, the scroll bar in Y axis will not be available, regardless of the content height.  
 **Default: false**
 
 ### scrollXMarginOffset
-The number of pixels the content width can surpass the container width without enabling the X axis scroll bar. Allows some "wiggle room" or "offset break", so that X axis scroll bar is not enabled just because of a few pixels.
+The number of pixels the content width can surpass the container width without enabling the X axis scroll bar. Allows some "wiggle room" or "offset break", so that X axis scroll bar is not enabled just because of a few pixels.  
 **Default: 0**
 
 ### scrollYMarginOffset
-The number of pixels the content height can surpass the container height without enabling the Y axis scroll bar. Allows some "wiggle room" or "offset break", so that Y axis scroll bar is not enabled just because of a few pixels.
+The number of pixels the content height can surpass the container height without enabling the Y axis scroll bar. Allows some "wiggle room" or "offset break", so that Y axis scroll bar is not enabled just because of a few pixels.  
 **Default: 0**
 
 How to Use
@@ -183,5 +183,5 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 Helpdesk
 --------
 
-If you have any idea to improve this project or any problems using this, please feel free to contact me.
+If you have any idea to improve this project or any problems using this, please feel free to contact me.  
 Email: noraesae@yuiazu.net


### PR DESCRIPTION
In testing this plugin, I noticed that another requirement is that the container div MUST have the overflow:hidden style.

I added this to the README, I think it will be useful for others to know this.
