### PR TITLE
Fix delta calculation in mouswheel handler

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -273,8 +273,8 @@
       var bindMouseWheelHandler = function () {
         var shouldPrevent = false;
         $this.bind('mousewheel' + eventClassName, function (e, deprecatedDelta, deprecatedDeltaX, deprecatedDeltaY) {
-          var deltaX = e.deltaX ? e.deltaX / 10 : deprecatedDeltaX,
-              deltaY = e.deltaY ? e.deltaY / 10 : deprecatedDeltaY;
+          var deltaX = e.deltaX || deprecatedDeltaX,
+              deltaY = e.deltaY || deprecatedDeltaY;
 
           if (!settings.useBothWheelAxes) {
             // deltaX will only be used for horizontal scrolling and deltaY will


### PR DESCRIPTION
Remove division by 10 of deltas, which makes scrolling slower than in previous versions.
Reverts 88d286957766e981a4f4c720f213164fc0f3f099

Tested with IE11, Firefox 27 and Google Chrome 33 - 35.

I don't know why this division was introduced, also couldn't find a hint on the jquery-mousewheel changelog that this is necessary. Also see examples/options-wheelSpeed.html - 'Slow: wheelSpeed:1' doesn't scroll at all if the delta values are divided by 10.
