### PR TITLE
Change mousewheel delta calculation logic.

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -277,10 +277,16 @@
 
       // bind handlers
       var bindMouseWheelHandler = function () {
+        // FIXME: Backward compatibility.
+        // After e.deltaFactor applied, wheelSpeed should have smaller value.
+        // Currently, there's no way to change the settings after the scrollbar initialized.
+        // But if the way is implemented in the future, wheelSpeed should be reset.
+        settings.wheelSpeed /= 10;
+
         var shouldPrevent = false;
         $this.bind('mousewheel' + eventClassName, function (e, deprecatedDelta, deprecatedDeltaX, deprecatedDeltaY) {
-          var deltaX = e.deltaX || deprecatedDeltaX,
-              deltaY = e.deltaY || deprecatedDeltaY;
+          var deltaX = e.deltaX * e.deltaFactor || deprecatedDeltaX,
+              deltaY = e.deltaY * e.deltaFactor || deprecatedDeltaY;
 
           if (!settings.useBothWheelAxes) {
             // deltaX will only be used for horizontal scrolling and deltaY will

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -343,23 +343,23 @@
 
           switch (e.which) {
           case 37: // left
-            deltaX = -3;
+            deltaX = -30;
             break;
           case 38: // up
-            deltaY = 3;
+            deltaY = 30;
             break;
           case 39: // right
-            deltaX = 3;
+            deltaX = 30;
             break;
           case 40: // down
-            deltaY = -3;
+            deltaY = -30;
             break;
           case 33: // page up
-            deltaY = 9;
+            deltaY = 90;
             break;
           case 32: // space bar
           case 34: // page down
-            deltaY = -9;
+            deltaY = -90;
             break;
           case 35: // end
             deltaY = -containerHeight;
@@ -371,8 +371,8 @@
             return;
           }
 
-          $this.scrollTop($this.scrollTop() - (deltaY * settings.wheelSpeed));
-          $this.scrollLeft($this.scrollLeft() + (deltaX * settings.wheelSpeed));
+          $this.scrollTop($this.scrollTop() - deltaY);
+          $this.scrollLeft($this.scrollLeft() + deltaX);
 
           shouldPrevent = shouldPreventDefault(deltaX, deltaY);
           if (shouldPrevent) {


### PR DESCRIPTION
Hello,

Recently, we moved to jquery-mousewheel 3.1.9, and it changes the way calculating the deltas. So I changed the logic a little before, but it made the scrolling extremely slow in some environments. So the change was reverted.

I just found that there's a value called `event.deltaFactor` in jquery-mousewheel, and I re-change the logic using `event.deltaFactor`. To prevent the problem like before, I hope to test it in many environments before applying it into the master branch. The change is tested with my Macbook Trackpad and Logitech Mouse in the latest Safari and Chrome. If there's no problem in other environments and seems good, I'll merge the patch.

You can test it with the example, `examples/options-wheelSpeed.html`. The terminal commands will be like this:

```
git clone https://github.com/noraesae/perfect-scrollbar.git -b mousewheel-speed
cd perfect-scrollbar
open examples/options-wheelSpeed.html
```

If there's any problem, please report it with comments. Any further contribution also will be welcomed.

Thanks in advance.
