### PR TITLE
Use innerWidth/Height instead of outerWidth/Height to determine the width/height of container

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -152,8 +152,8 @@
       };
 
       var updateBarSizeAndPosition = function () {
-        containerWidth = settings.includePadding ? $this.outerWidth() : $this.width();
-        containerHeight = settings.includePadding ? $this.outerHeight() : $this.height();
+        containerWidth = settings.includePadding ? $this.innerWidth() : $this.width();
+        containerHeight = settings.includePadding ? $this.innerHeight() : $this.height();
         contentWidth = $this.prop('scrollWidth');
         contentHeight = $this.prop('scrollHeight');
 


### PR DESCRIPTION
As per jQuery docs the `innerWidth` method is the one that includes padding (https://api.jquery.com/innerWidth/), while the previously used `outerWidth` includes border width as well (https://api.jquery.com/outerWidth/). Therefore I think the use of `innerWidth` makes more sense for getting the container width with padding in the code (plus a setting name `includePadding` suggest only padding width is taken into account as an extra for container width determination and might be confusing otherwise).

Thanks, please excuse me if I was not attentive and missed something from the code.
