### PR TITLE
Prevent scrollbar rail disappearance during scrolling

### DIFF
--- a/src/perfect-scrollbar.css
+++ b/src/perfect-scrollbar.css
@@ -27,6 +27,7 @@
 }
 
 .ps-container .ps-scrollbar-x-rail.in-scrolling {
+    background-color: #eee;
     opacity: 0.9;
     filter: alpha(opacity = 90);
 }
@@ -60,6 +61,7 @@
 }
 
 .ps-container .ps-scrollbar-y-rail.in-scrolling {
+    background-color: #eee;
     opacity: 0.9;
     filter: alpha(opacity = 90);
 }


### PR DESCRIPTION
This update to styles makes scrollbar rail stay visible while you drag the scrollbar along it and accidentally leave the area of the rail with mouse pointer (this should not affect scrolling with mousewheel)
