### PR TITLE
Apply .ps-active class when area scrollable

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -192,6 +192,12 @@
 
         $scrollbarX.css({left: scrollbarXLeft, width: scrollbarXWidth});
         $scrollbarY.css({top: scrollbarYTop, height: scrollbarYHeight});
+
+        if(scrollbarXActive || scrollbarYActive) {
+          $this.addClass('ps-active');
+        } else {
+          $this.removeClass('ps-active');
+        }
       };
 
       var updateBarSizeAndPosition = function () {

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -193,7 +193,7 @@
         $scrollbarX.css({left: scrollbarXLeft, width: scrollbarXWidth});
         $scrollbarY.css({top: scrollbarYTop, height: scrollbarYHeight});
 
-        if(scrollbarXActive || scrollbarYActive) {
+        if (scrollbarXActive || scrollbarYActive) {
           $this.addClass('ps-active');
         } else {
           $this.removeClass('ps-active');


### PR DESCRIPTION
For a project I'm currently working on I needed to know when the area perfect scrollbar is applied to is actually scrollable so I can adjust the styling for the containing elements e.g. I want to remove the padding that the scrollbar covers when it's not active.

This piece of code works fine for me but I admit it's a quick fix. There might be a better place to put it. I do think it's a useful feature though and should be a part of this plugin.
