### PR TITLE
ShadowDom form elements are considered for preventing scrolling by keyevent

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -431,7 +431,16 @@
             return;
           }
 
-          if (!hovered || $(document.activeElement).is(":input,[contenteditable]")) {
+          if (!hovered) {
+            return;
+          }
+
+          var activeElement = document.activeElement;
+          // go deeper if element is a webcomponent
+          while (activeElement.shadowRoot) {
+            activeElement = activeElement.shadowRoot.activeElement;
+          }
+          if ($(activeElement).is(":input,[contenteditable]")) {
             return;
           }
 


### PR DESCRIPTION
I recently had a problem with form elements and scrolling with keys - I couldn't have spaces in my textareas as perfect-scrollbar handled the space keydown event. I posted a message in #103 , been redirected to #123 . My problem should not have occurred...

I finally realized jquery could not identify my textarea as an input element because I use shadowdom and document.activeElement return the shadowdom element and NOT the "final" element. See : http://www.w3.org/TR/shadow-dom/#active-element .

This PR resolves the problem. I thought it deserved a comment, I made it simple as the other comments in the code are mostly short.

I'm not sure this is the only problem perfect-scrollbar could have with shadowdom. I'll come back if I discover any other one...
