### PR TITLE
Don't handle mouse pointer events as touch in IE10

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -658,7 +658,7 @@
           if (event.targetTouches && event.targetTouches.length === 1) {
             return true;
           }
-          if (event.pointerType && event.pointerType !== 'mouse') {
+          if (event.pointerType && event.pointerType !== 'mouse' && event.pointerType !== event.MSPOINTER_TYPE_MOUSE) {
             return true;
           }
           return false;


### PR DESCRIPTION
IE10 returns `MSPOINTER_TYPE_MOUSE` instead of `"mouse"` as source for pointer events (http://msdn.microsoft.com/en-us/library/ie/hh772359.aspx).

In case `event.MSPOINTER_TYPE_MOUSE` is `undefined` (all browsers but IE10) the added comparison will always resolve to true, because we already checked that `event.pointerType` is not undefined earlier.
