### PR TITLE
Add disablePropagation option.

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -28,6 +28,7 @@
   var defaultSettings = {
     wheelSpeed: 1,
     wheelPropagation: false,
+    disablePropagation: true,
     minScrollbarLength: null,
     maxScrollbarLength: null,
     useBothWheelAxes: false,
@@ -320,7 +321,7 @@
             return false;
           }
           if ((scrollTop === 0 && deltaY > 0) || (scrollTop >= contentHeight - containerHeight && deltaY < 0)) {
-            return !settings.wheelPropagation;
+            return settings.disablePropagation && !settings.wheelPropagation;
           }
         }
 
@@ -330,10 +331,10 @@
             return false;
           }
           if ((scrollLeft === 0 && deltaX < 0) || (scrollLeft >= contentWidth - containerWidth && deltaX > 0)) {
-            return !settings.wheelPropagation;
+            return settings.disablePropagation && !settings.wheelPropagation;
           }
         }
-        return true;
+        return settings.disablePropagation;
       }
 
       function bindMouseWheelHandler() {


### PR DESCRIPTION
I added new option for perfect-scrollbar to disable prevent propagation during scrollbar update. By default, this options is set to true to keep compatibility.
I need to enable propagation even if the scroll doesn't reach the end of the side (with wheelPropagation option), to be able to listen this event on my code to trigger some action.
I hesitated between trigger some built-in event, but I didn't want to introduce some new logical feature in your work, so I extended it by adding this option.
With this option, the propagation will be controlled in my-side, after triggering my actions.
