### PR TITLE
No longer remove classes at the beginning of updateGeometry()

### DIFF
--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -73,7 +73,7 @@
       // Catch options
       if (option === 'update') {
         if ($this.data('perfect-scrollbar-update')) {
-          $this.data('perfect-scrollbar-update')();
+          $this.data('perfect-scrollbar-update')(true);
         }
         return $this;
       }
@@ -204,7 +204,12 @@
         $scrollbarY.css({top: scrollbarYTop, height: scrollbarYHeight - railBorderYWidth});
       }
 
-      function updateGeometry() {
+      function updateGeometry(hideRails) {
+        if (hideRails) {
+          $scrollbarXRail.hide();
+          $scrollbarYRail.hide();
+        }
+
         containerWidth = settings.includePadding ? $this.innerWidth() : $this.width();
         containerHeight = settings.includePadding ? $this.innerHeight() : $this.height();
         contentWidth = $this.prop('scrollWidth');
@@ -242,6 +247,11 @@
         }
 
         updateCss();
+
+        if (hideRails) {
+          $scrollbarXRail.show();
+          $scrollbarYRail.show();
+        }
 
         $this[scrollbarXActive ? 'addClass' : 'removeClass']('ps-active-x');
         $this[scrollbarYActive ? 'addClass' : 'removeClass']('ps-active-y');

--- a/src/perfect-scrollbar.js
+++ b/src/perfect-scrollbar.js
@@ -205,10 +205,6 @@
       }
 
       function updateGeometry() {
-        // Hide scrollbars not to affect scrollWidth and scrollHeight
-        $this.removeClass('ps-active-x');
-        $this.removeClass('ps-active-y');
-
         containerWidth = settings.includePadding ? $this.innerWidth() : $this.width();
         containerHeight = settings.includePadding ? $this.innerHeight() : $this.height();
         contentWidth = $this.prop('scrollWidth');
@@ -247,12 +243,8 @@
 
         updateCss();
 
-        if (scrollbarXActive) {
-          $this.addClass('ps-active-x');
-        }
-        if (scrollbarYActive) {
-          $this.addClass('ps-active-y');
-        }
+        $this[scrollbarXActive ? 'addClass' : 'removeClass']('ps-active-x');
+        $this[scrollbarYActive ? 'addClass' : 'removeClass']('ps-active-y');
       }
 
       function bindMouseScrollXHandler() {


### PR DESCRIPTION
Chrome and Firefox can be very slow when finding heights and widths
for large scrollable divs just after adding or removing classes.
Since the scrollbars should not affect computed height and width,
there is no need to remove the classes that makes them visible at
the beginning of updateGeometry().
