### PR TITLE
False selection detection when typing something into input

### DIFF
--- a/src/js/plugin/handler/selection.js
+++ b/src/js/plugin/handler/selection.js
@@ -10,7 +10,7 @@ var h = require('../../lib/helper')
 function bindSelectionHandler(element, i) {
   function getRangeNode() {
     var selection = window.getSelection ? window.getSelection() :
-                    document.getSelection ? document.getSelection() : {rangeCount: 0};
+                    document.getSelection ? document.getSelection() : '';
     if (selection.toString().length === 0) {
       return null;
     } else {

--- a/src/js/plugin/handler/selection.js
+++ b/src/js/plugin/handler/selection.js
@@ -10,8 +10,8 @@ var h = require('../../lib/helper')
 function bindSelectionHandler(element, i) {
   function getRangeNode() {
     var selection = window.getSelection ? window.getSelection() :
-                    document.getSlection ? document.getSlection() : {rangeCount: 0};
-    if (selection.rangeCount === 0) {
+                    document.getSelection ? document.getSelection() : {rangeCount: 0};
+    if (selection.toString().length === 0) {
       return null;
     } else {
       return selection.getRangeAt(0).commonAncestorContainer;


### PR DESCRIPTION
`selection.rangeCount` will return 1 when user is typing something in a
form widget. This will consequently trigger unvoluntary scrolling when
the mouse is moved outside of scrollable area. Checking the actual
length of selected text doesn't trigger this behaviour.

The undesired behaviour can be seen here: http://jsfiddle.net/o2pj5ppz/2/embedded/result/
Same setup with the changes from this commit: http://jsfiddle.net/o2pj5ppz/4/embedded/result/
