### PR TITLE
Disable selection handler after keyup

### DIFF
--- a/src/js/plugin/handler/selection.js
+++ b/src/js/plugin/handler/selection.js
@@ -51,12 +51,15 @@ function bindSelectionHandler(element, i) {
       stopScrolling();
     }
   });
-  i.event.bind(window, 'mouseup', function () {
+
+  function notSelected() {
     if (isSelected) {
       isSelected = false;
       stopScrolling();
     }
-  });
+  }
+  i.event.bind(window, 'mouseup', notSelected);
+  i.event.bind(window, 'keyup', notSelected);
 
   i.event.bind(window, 'mousemove', function (e) {
     if (isSelected) {


### PR DESCRIPTION
Fixes a bug where after after entering a character in a input, mouse movement caused scrolling as through the user was selecting a range of text.
