### PR TITLE
parseInt() returns NaN when the first argument is empty string.

### DIFF
--- a/src/js/lib/helper.js
+++ b/src/js/lib/helper.js
@@ -8,7 +8,7 @@ var cls = require('./class')
 
 exports.toInt = function (x) {
   if (typeof x === 'string') {
-    return parseInt(x, 10);
+    return parseInt(x, 10) || 0;
   } else {
     return ~~x;
   }


### PR DESCRIPTION
ex) parseInt('', 10) -> NaN
