### PR TITLE
Quick fix for trackpad/mouse-wheel usage:

### DIFF
--- a/src/js/plugin/handler/mouse-wheel.js
+++ b/src/js/plugin/handler/mouse-wheel.js
@@ -72,7 +72,7 @@ function bindMouseWheelHandler(element, i) {
     var deltaY = delta[1];
 
     shouldPrevent = false;
-    if (!i.settings.useBothWheelAxes) {
+    if (i.settings.useBothWheelAxes) {
       // deltaX will only be used for horizontal scrolling and deltaY will
       // only be used for vertical scrolling - this is the default
       element.scrollTop = element.scrollTop - (deltaY * i.settings.wheelSpeed);
@@ -80,18 +80,18 @@ function bindMouseWheelHandler(element, i) {
     } else if (i.scrollbarYActive && !i.scrollbarXActive) {
       // only vertical scrollbar is active and useBothWheelAxes option is
       // active, so let's scroll vertical bar using both mouse wheel axes
-      if (deltaY) {
+      if (Math.abs(deltaY) > Math.abs(deltaX)) {
         element.scrollTop = element.scrollTop - (deltaY * i.settings.wheelSpeed);
-      } else {
+      } else if (Math.abs(deltaY) < Math.abs(deltaX)) {
         element.scrollTop = element.scrollTop + (deltaX * i.settings.wheelSpeed);
       }
       shouldPrevent = true;
     } else if (i.scrollbarXActive && !i.scrollbarYActive) {
       // useBothWheelAxes and only horizontal bar is active, so use both
       // wheel axes for horizontal bar
-      if (deltaX) {
+      if (Math.abs(deltaY) < Math.abs(deltaX)) {
         element.scrollLeft = element.scrollLeft + (deltaX * i.settings.wheelSpeed);
-      } else {
+      } else if (Math.abs(deltaY) > Math.abs(deltaX)) {
         element.scrollLeft = element.scrollLeft - (deltaY * i.settings.wheelSpeed);
       }
       shouldPrevent = true;


### PR DESCRIPTION
- if (i.settings.useBothWheelAxes check was reversed
- Jerky behavior fixed by using the greater of deltaX and deltaY instead
  of just checking to see if one or the other is present.
