### PR TITLE
changed toInt()'s function behavior

### DIFF
--- a/src/js/lib/helper.js
+++ b/src/js/lib/helper.js
@@ -8,7 +8,7 @@ var cls = require('./class')
 
 exports.toInt = function (x) {
   if (typeof x === 'string') {
-    return parseInt(x, 10);
+    return parseInt(x, 10) || 0;
   } else {
     return ~~x;
   }


### PR DESCRIPTION
When toInt() is called is with the result of getting a computed CSS style via the exported "css" function of the DOM module (e.g. as in the Instance prototype), that might return an empty string, it returned NaN. This caused some calculations to be broken, e.g. for the scrollbar's rail height. This simple fix will always return 0 instead of NaN and thus fixes scrollbar rails calculation.
