### PR TITLE
Add null-check when updating or destroying an instance.

### DIFF
--- a/src/js/plugin/destroy.js
+++ b/src/js/plugin/destroy.js
@@ -10,11 +10,14 @@ var d = require('../lib/dom')
 module.exports = function (element) {
   var i = instances.get(element);
 
-  i.event.unbindAll();
-  d.remove(i.scrollbarX);
-  d.remove(i.scrollbarY);
-  d.remove(i.scrollbarXRail);
-  d.remove(i.scrollbarYRail);
+  if (i){
+    i.event.unbindAll();
+    d.remove(i.scrollbarX);
+    d.remove(i.scrollbarY);
+    d.remove(i.scrollbarXRail);
+    d.remove(i.scrollbarYRail);
+  }
+
   h.removePsClasses(element);
 
   instances.remove(element);

--- a/src/js/plugin/destroy.js
+++ b/src/js/plugin/destroy.js
@@ -10,15 +10,16 @@ var d = require('../lib/dom')
 module.exports = function (element) {
   var i = instances.get(element);
 
-  if (!i) {
-    throw new Error('perfect-scrollbar: instance not found');
+  if (i) {
+    i.event.unbindAll();
+    d.remove(i.scrollbarX);
+    d.remove(i.scrollbarY);
+    d.remove(i.scrollbarXRail);
+    d.remove(i.scrollbarYRail);
+  }else {
+    console.error('perfect-scrollbar: instance not found');
   }
 
-  i.event.unbindAll();
-  d.remove(i.scrollbarX);
-  d.remove(i.scrollbarY);
-  d.remove(i.scrollbarXRail);
-  d.remove(i.scrollbarYRail);
   h.removePsClasses(element);
 
   instances.remove(element);

--- a/src/js/plugin/destroy.js
+++ b/src/js/plugin/destroy.js
@@ -10,7 +10,7 @@ var d = require('../lib/dom')
 module.exports = function (element) {
   var i = instances.get(element);
 
-  if (i){
+  if (i) {
     i.event.unbindAll();
     d.remove(i.scrollbarX);
     d.remove(i.scrollbarY);

--- a/src/js/plugin/update.js
+++ b/src/js/plugin/update.js
@@ -11,6 +11,10 @@ var d = require('../lib/dom')
 module.exports = function (element) {
   var i = instances.get(element);
 
+  if (!i) {
+    throw new Error('perfect-scrollbar: instance not found');
+  }
+
   // Recalcuate negative scrollLeft adjustment
   i.negativeScrollAdjustment = i.isNegativeScroll ? element.scrollWidth - element.clientWidth : 0;
 


### PR DESCRIPTION
Hey Jun,

(not sure if the best practice was to do another pull request) but here it is.  So I've found the issue is with the scroll bar being a direct child of an angular ui-router element.  I have added in the console.error() as you suggested.  But using console isn't supported by all browsers, (IE) especially, and not sure it's good to use here.  I'd suggest removing it, imo.

Thanks,

Adam
