### PR TITLE
Add shift+space support for keyboard

### DIFF
--- a/src/js/plugin/handler/keyboard.js
+++ b/src/js/plugin/handler/keyboard.js
@@ -80,6 +80,12 @@ function bindKeyboardHandler(element, i) {
       deltaY = 90;
       break;
     case 32: // space bar
+      if (e.shiftKey) {
+        deltaY = 90;
+      } else {
+        deltaY = -90;
+      }
+      break;
     case 34: // page down
       deltaY = -90;
       break;


### PR DESCRIPTION
Hello @noraesae , native scrollbars have shift+space keymap for scrolling upwards so I thought it might be good to have that in perfect-scrollbar as well.
