### PR TITLE
Touchpad/Trackpad scrolling IE10+ and Edge

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -63,8 +63,19 @@ $ps-bar-hover: #999;
 
 .ps-container {
   -ms-touch-action: none;
+  touch-action: none;
   overflow: hidden !important;
-
+  -ms-overflow-style: none;
+  
+  // Edge
+  @supports (-ms-overflow-style: none) { 
+    overflow: auto !important;
+  }
+  // IE10+
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) { 
+    overflow: auto !important;
+  }
+  
   &.ps-active-x > .ps-scrollbar-x-rail,
   &.ps-active-y > .ps-scrollbar-y-rail {
     display: block;


### PR DESCRIPTION
Right now you can't scroll with your touchpad/trackpad on a element that
has the perfect scrollbar in IE10+ and Edge.
By using the property '-ms-overflow-style' (Supported in IE10+ and Edge)
too hide the overflow instead of the default 'overflow' property, you
keep the scrolling with touchpad/trackpad functionality.
