### PR TITLE
Fixes touch event handling in nested scrollbar containers

### DIFF
--- a/src/js/plugin/handler/touch.js
+++ b/src/js/plugin/handler/touch.js
@@ -90,6 +90,9 @@ function bindTouchHandler(element, i, supportsTouch, supportsIePointer) {
     }
   }
   function touchMove(e) {
+    if (!inLocalTouch && i.settings.swipePropagation) {
+      touchStart(e);
+    }
     if (!inGlobalTouch && inLocalTouch && shouldHandle(e)) {
       var touch = getTouch(e);
 


### PR DESCRIPTION
If you have one perfect-scrollbar container within another, on mobile devices, initiating a touch in the inner container, then scrolling beyond the bounds of the inner container, does nothing to the outer container even with swipePropagation enabled.

I'm not 100% sure why it works, but this hack fixes it.
