### PR TITLE
Allow children native scroll

### DIFF
--- a/examples/children-native-scroll.html
+++ b/examples/children-native-scroll.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>perfect-scrollbar example</title>
+    <link href="../dist/css/perfect-scrollbar.css" rel="stylesheet">
+    <script src="../dist/js/perfect-scrollbar.js"></script>
+    <style>
+      .contentHolder { position:relative; margin:0px auto; padding:0px; width: 600px; height: 400px; overflow: auto; }
+      .contentHolder .content { background-image: url('./azusa.jpg'); width: 1280px; height: 720px; }
+      .my-list {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 130px;
+        height: 200px;
+        overflow: scroll;
+        background-color: rgba(255,255,255,0.6);
+      }
+
+      .my-list-two {
+        left: 140px;
+        overflow: auto;
+      }
+
+      .my-list-three {
+        left: 290px;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+      }
+
+      li {
+        box-sizing: border-box;
+        padding: 10px 5px;
+        border-width: 0 0 1px 0;
+        list-style-type: none;
+        margin: 0;
+      }
+
+      li:nth-child(even) {
+        background-color: rgba(0,0,0,0.5);
+      }
+
+      .my-list-horizontal {
+        height: 75px;
+        top: 210px;
+      }
+
+      .my-list-horizontal ul {
+        box-sizing: border-box;
+        padding: 5px;
+        display: inline-block;
+        width: 970px;
+      }
+
+      .my-list-horizontal li {
+        display: inline-block;
+        width: 120px;
+        margin: 0;
+        border-width: 0 1px 0 0;
+      }
+    </style>
+  </head>
+  <div id="Default" class="contentHolder">
+    <div class="content">
+      <div class="my-list">
+        <code>overflow: scroll</code>
+        <ul><li>One</li><li>Two</li><li>Three</li><li>Four</li><li>Five</li><li>Six</li><li>Seven</li><li>Eight</li></ul>
+      </div>
+      <div class="my-list my-list-two">
+        <code>overflow: auto</code>
+        <ul><li>One</li><li>Two</li><li>Three</li><li>Four</li><li>Five</li><li>Six</li><li>Seven</li><li>Eight</li></ul>
+      </div>
+      <div class="my-list my-list-three">
+        <code>overflow: scroll</code>
+        <ul><li>One</li><li>Two</li><li>Three</li></ul>
+      </div>
+      <div class="my-list my-list-horizontal">
+        <code>overflow: auto</code>
+        <ul><li>One</li><li>Two</li><li>Three</li><li>Four</li><li>Five</li><li>Six</li><li>Seven</li><li>Eight</li></ul>
+      </div>
+    </div>
+  </div>
+  <script type="text/javascript">
+     window.onload = function () {
+      Ps.initialize(document.querySelector('#Default'));
+    };
+  </script>
+  </body>
+</html>
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,10 @@ var gulp = require('gulp')
   , autoprefixer = require('gulp-autoprefixer')
   , zip = require('gulp-zip');
 
+// Support for Node 0.10
+// See https://github.com/webpack/css-loader/issues/144
+require('es6-promise').polyfill();
+
 var version = '/* perfect-scrollbar v' + require('./package').version + ' */\n';
 
 gulp.task('lint', function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perfect-scrollbar",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "Minimalistic but perfect custom scrollbar plugin",
   "author": "Hyunje Alex Jun <me@noraesae.net>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "gulp-uglify": "^1.4.1",
     "gulp-zip": "^3.0.2",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "es6-promise": "^3.1.2"
   },
   "scripts": {
     "test": "gulp",

--- a/src/js/plugin/handler/mouse-wheel.js
+++ b/src/js/plugin/handler/mouse-wheel.js
@@ -76,6 +76,26 @@ function bindMouseWheelHandler(element, i) {
     return false;
   }
 
+  // figure out if any of the target element ancestors has a overflow of scroll
+  // and thus should capture mouse wheel events
+  function findScrollParent(elem, e) {
+    var parent = elem.parentNode;
+    if(parent === e.currentTarget) {
+      return parent;
+    }
+    if(
+      (window.getComputedStyle(parent)['overflow'] || '').match(/(scroll|auto)/) &&
+      (parent.clientHeight < parent.scrollHeight || parent.clientWidth < parent.scrollWidth)
+    ) {
+      return parent;
+    }
+    return findScrollParent(parent, e);
+  }
+
+  function shouldBeConsumedByChild(e) {
+    return findScrollParent(e.target, e) !== e.currentTarget;
+  }
+
   function mousewheelHandler(e) {
     var delta = getDeltaFromEvent(e);
 
@@ -83,6 +103,9 @@ function bindMouseWheelHandler(element, i) {
     var deltaY = delta[1];
 
     if (shouldBeConsumedByTextarea(deltaX, deltaY)) {
+      return;
+    }
+    if (shouldBeConsumedByChild(e)) {
       return;
     }
 


### PR DESCRIPTION
If a child of an element with perfect scrollbar applied needed to scroll, e.g. by setting `overflow: scroll` then the mouse wheel event would be captured by the ancestor that has perfect scrollbar applied.

Detect these cases and don't capture nor handle the event on the perfect scrollbar ancestor.

Related to #455 
