### PR TITLE
Fix for stopPropagation on IE

### DIFF
--- a/src/js/plugin/handler/click-rail.js
+++ b/src/js/plugin/handler/click-rail.js
@@ -9,7 +9,14 @@ function bindClickRailHandler(element, i) {
   function pageOffset(el) {
     return el.getBoundingClientRect();
   }
-  var stopPropagation = window.Event.prototype.stopPropagation.bind;
+  var stopPropagation;
+  if (window.Event.prototype.stopPropagation) {
+    stopPropagation = window.Event.prototype.stopPropagation.bind;
+  } else {
+    stopPropagation = function() {
+      this.cancelBubble = true;
+    }.bind
+  };
 
   if (i.settings.stopPropagationOnClick) {
     i.event.bind(i.scrollbarY, 'click', stopPropagation);

--- a/src/js/plugin/handler/click-rail.js
+++ b/src/js/plugin/handler/click-rail.js
@@ -13,10 +13,10 @@ function bindClickRailHandler(element, i) {
   if (window.Event.prototype.stopPropagation) {
     stopPropagation = window.Event.prototype.stopPropagation.bind;
   } else {
-    stopPropagation = function() {
+    stopPropagation = function () {
       this.cancelBubble = true;
-    }.bind
-  };
+    }.bind;
+  }
 
   if (i.settings.stopPropagationOnClick) {
     i.event.bind(i.scrollbarY, 'click', stopPropagation);


### PR DESCRIPTION
window.Event.prototype.stopPropagation does not exist in IE. 

cancelBubble can be used instead
