### PR TITLE
crossdomain issue fix

### DIFF
--- a/src/js/lib/dom.js
+++ b/src/js/lib/dom.js
@@ -14,7 +14,7 @@ DOM.appendTo = function (child, parent) {
 };
 
 function cssGet(element, styleName) {
-  return window.getComputedStyle(element)[styleName];
+  return element.style[styleName]; 
 }
 
 function cssSet(element, styleName, styleValue) {


### PR DESCRIPTION
Thank you very much for your contribution! Please make sure the followings
are checked.
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Perfect Scrollbar JSFiddle: https://jsfiddle.net/DanielApt/xv0rrxv3/
  - With jQuery: https://jsfiddle.net/DanielApt/gbfLazpx/
- [x] Refer to concerning issues if exist

`window.getComputedStyle` doesn't work in Firefox when embedding perfectscrollbar in some page in an iframe on some other domain/subdomain. it cannot access window from there. it throws a "`Given URL is not allowed by the Application configuration`" error and expects some special headers.

when using `element.style` there are no errors and no need for extra cross-domain headers with the plugin.

please note that this happened only on firefox, it worked fine in chrome
