### PR TITLE
Use only getAttribute and setAttribute to maximize browser compatibility, due to partial support of the .dataset method

### DIFF
--- a/src/js/plugin/instances.js
+++ b/src/js/plugin/instances.js
@@ -79,27 +79,15 @@ function Instance(element) {
 }
 
 function getId(element) {
-  if (typeof element.dataset === 'undefined') {
-    return element.getAttribute('data-ps-id');
-  } else {
-    return element.dataset.psId;
-  }
+  return element.getAttribute('data-ps-id');
 }
 
 function setId(element, id) {
-  if (typeof element.dataset === 'undefined') {
-    element.setAttribute('data-ps-id', id);
-  } else {
-    element.dataset.psId = id;
-  }
+  element.setAttribute('data-ps-id', id);
 }
 
 function removeId(element) {
-  if (typeof element.dataset === 'undefined') {
-    element.removeAttribute('data-ps-id');
-  } else {
-    delete element.dataset.psId;
-  }
+  element.removeAttribute('data-ps-id');
 }
 
 exports.add = function (element) {


### PR DESCRIPTION
refer to #441 pull request
I think would be better to simply use getAttribute and setAttribute instead of dataset. It has a better performance (see this [jsperf](https://jsperf.com/dataset-vs-getattribute-and-setattribute/3)), and will keep support good for IE9 up and of course also to all others browsers.
