### PR TITLE
Always check parentNode before removing dom element

### DIFF
--- a/src/js/lib/dom.js
+++ b/src/js/lib/dom.js
@@ -66,12 +66,13 @@ DOM.matches = function (element, query) {
 };
 
 DOM.remove = function (element) {
+  if (!element.parentNode) {
+    return;
+  }
   if (typeof element.remove !== 'undefined') {
     element.remove();
   } else {
-    if (element.parentNode) {
-      element.parentNode.removeChild(element);
-    }
+    element.parentNode.removeChild(element);
   }
 };
 


### PR DESCRIPTION
Prototype.js overrides HTMLElement.prototype.remove, but there is a defect in the implementation. It does not check parentNode before removing. Sometime it will cause js error when we try to destroy Ps.

Demo: https://jsfiddle.net/Lcm1kL17/
