### PR TITLE
Rounding error fix when scrollbar is all the way down or right

### DIFF
--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -54,7 +54,7 @@ module.exports = function (element, axis, value) {
   if (axis === 'top' && value >= i.contentHeight - i.containerHeight) {
     // don't allow scroll past container
     value = i.contentHeight - i.containerHeight;
-    if (Math.abs(value - element.scrollTop) <= 1) {
+    if (value - element.scrollTop <= 1) {
       // mitigates rounding errors on non-subpixel scroll values
       value = element.scrollTop;
     } else {
@@ -66,7 +66,7 @@ module.exports = function (element, axis, value) {
   if (axis === 'left' && value >= i.contentWidth - i.containerWidth) {
     // don't allow scroll past container
     value = i.contentWidth - i.containerWidth;
-    if (Math.abs(value - element.scrollLeft) <= 1) {
+    if (value - element.scrollLeft <= 1) {
       // mitigates rounding errors on non-subpixel scroll values
       value = element.scrollLeft;
     } else {

--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -52,12 +52,26 @@ module.exports = function (element, axis, value) {
   var i = instances.get(element);
 
   if (axis === 'top' && value >= i.contentHeight - i.containerHeight) {
-    element.scrollTop = value = i.contentHeight - i.containerHeight; // don't allow scroll past container
+    // don't allow scroll past container
+    value = i.contentHeight - i.containerHeight;
+    if (Math.abs(value - element.scrollTop) <= 1) {
+      // mitigates rounding errors on non-subpixel scroll values
+      value = element.scrollTop;
+    } else {
+      element.scrollTop = value;
+    }
     element.dispatchEvent(yEndEvent);
   }
 
   if (axis === 'left' && value >= i.contentWidth - i.containerWidth) {
-    element.scrollLeft = value = i.contentWidth - i.containerWidth; // don't allow scroll past container
+    // don't allow scroll past container
+    value = i.contentWidth - i.containerWidth;
+    if (Math.abs(value - element.scrollLeft) <= 1) {
+      // mitigates rounding errors on non-subpixel scroll values
+      value = element.scrollLeft;
+    } else {
+      element.scrollLeft = value;
+    }
     element.dispatchEvent(xEndEvent);
   }
 


### PR DESCRIPTION
Hi there and thanks for perfect-scrollbar.

I noticed a bug when the scrollbar is in the far bottom / right position. Basically each time I scrolled further (with the bar or with the mouse wheel) it would move one more pixel. I found this problem was mentioned in issue #13, but it did not happen all the time, so I suspected rounding errors and found it was likely (see [here](http://stackoverflow.com/questions/11724556/how-to-get-the-maximum-scroll-position-of-a-page-precisely)).

A simple way to mitigate this (as most browsers don't support sub-pixel scroll values) is to test if the delta between the wanted scroll value and the current one is 1 or lower, and consider there should be no change when it's the case. Hence this PR.
