### PR TITLE
Add theme option to scale (grow) rails on hover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 /dist
 .idea
+examples/custom-theme.css

--- a/examples/custom-theme.html
+++ b/examples/custom-theme.html
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <title>perfect-scrollbar example</title>
-  <link href="../dist/css/perfect-scrollbar.css" rel="stylesheet">
+  <link href="custom-theme.css" rel="stylesheet">
   <script src="../dist/js/perfect-scrollbar.js"></script>
   <style>
     .contentHolder { position:relative; margin:0px auto; padding:0px; width: 600px; height: 400px; overflow: auto; }
@@ -19,7 +19,7 @@
   var $ = document.querySelector.bind(document);
   window.onload = function () {
     Ps.initialize($('#Default'), {
-      theme: 'big-and-ugly'
+      theme: 'custom-theme'
     });
   };
 </script>

--- a/examples/custom-theme.scss
+++ b/examples/custom-theme.scss
@@ -2,11 +2,10 @@
 
 .ps-theme-custom-theme {
   @include ps-container(map-merge($ps-theme-default, (
-          border-radius: 0,
-          scrollbar-x-rail-height: 20px,
-          scrollbar-x-height: 20px,
-          scrollbar-y-rail-width: 20px,
-          scrollbar-y-width: 20px,
-          scrollbar-rail-scale-hover: 1.5
+          scrollbar-rail-scale-hover: 1.5,
+          scrollbar-y-rail-width: 8px,
+          scrollbar-y-width: 6px,
+          scrollbar-x-rail-height: 8px,
+          scrollbar-x-height: 6px
   )));
 }

--- a/examples/custom-theme.scss
+++ b/examples/custom-theme.scss
@@ -1,0 +1,12 @@
+@import '../src/css/main';
+
+.ps-theme-custom-theme {
+  @include ps-container(map-merge($ps-theme-default, (
+          border-radius: 0,
+          scrollbar-x-rail-height: 20px,
+          scrollbar-x-height: 20px,
+          scrollbar-y-rail-width: 20px,
+          scrollbar-y-width: 20px,
+          scrollbar-rail-scale-hover: 1.5
+  )));
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ gulp.task('js:min', ['clean:js:min'], function () {
 });
 
 gulp.task('clean:css', function () {
-  return del(['./dist/css/perfect-scrollbar.css']);
+  return del(['./dist/css/perfect-scrollbar.css', './examples/custom-theme.css']);
 });
 
 gulp.task('clean:css:min', function () {
@@ -91,13 +91,25 @@ gulp.task('clean:css:min', function () {
 });
 
 gulp.task('css', ['clean:css'], function () {
-  return gulp.src('./src/css/main.scss')
+  var main = gulp
+    .src('./src/css/main.scss')
     .pipe(sass())
     .pipe(autoprefixer(autoPrefixerConfig))
     .pipe(insert.prepend(version))
     .pipe(rename('perfect-scrollbar.css'))
     .pipe(gulp.dest('./dist/css'))
     .pipe(connect.reload());
+
+  var custom = gulp
+    .src('./examples/custom-theme.scss')
+    .pipe(sass())
+    .pipe(autoprefixer(autoPrefixerConfig))
+    .pipe(insert.prepend(version))
+    .pipe(rename('custom-theme.css'))
+    .pipe(gulp.dest('./examples'))
+    .pipe(connect.reload());
+
+  return stream.concat(main, custom);
 });
 
 gulp.task('css:min', ['clean:css:min'], function () {

--- a/src/css/mixins.scss
+++ b/src/css/mixins.scss
@@ -73,7 +73,7 @@
     &:active {
       height: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-x-rail-height);
       > .ps-scrollbar-x {
-        height: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-x-rail-height);
+        height: 100%;
       }
     }
 
@@ -93,7 +93,7 @@
     &:active {
       width: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-y-rail-width);
       > .ps-scrollbar-y {
-        width: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-y-rail-width);
+        width: 100%;
       }
     }
 

--- a/src/css/mixins.scss
+++ b/src/css/mixins.scss
@@ -3,7 +3,7 @@
   position: absolute; /* please don't change 'position' */
   border-radius: map_get($theme, border-radius);
   opacity: map_get($theme, rail-default-opacity);
-  transition: background-color .2s linear, opacity .2s linear;
+  transition: background-color .2s linear, opacity .2s linear, height .2s linear, width .2s ease-in-out;;
 }
 
 @mixin scrollbar-rail-hover($theme) {
@@ -15,7 +15,7 @@
   position: absolute; /* please don't change 'position' */
   background-color: map_get($theme, bar-container-hover-bg);
   border-radius: map_get($theme, border-radius);
-  transition: background-color .2s linear;
+  transition: background-color .2s linear, height .2s linear, width .2s ease-in-out;
 }
 
 @mixin scrollbar-hover($theme) {
@@ -69,6 +69,14 @@
     bottom: map_get($theme, scrollbar-x-rail-bottom); /* there must be 'bottom' for ps-scrollbar-x-rail */
     height: map_get($theme, scrollbar-x-rail-height);
 
+    &:hover,
+    &:active {
+      height: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-x-rail-height);
+      > .ps-scrollbar-x {
+        height: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-x-rail-height);
+      }
+    }
+
     > .ps-scrollbar-x {
       @include scrollbar-default($theme);
       bottom: map_get($theme, scrollbar-x-bottom); /* there must be 'bottom' for ps-scrollbar-x */
@@ -80,6 +88,14 @@
     @include scrollbar-rail-default($theme);
     right: map_get($theme, scrollbar-y-rail-right); /* there must be 'right' for ps-scrollbar-y-rail */
     width: map_get($theme, scrollbar-y-rail-width);
+
+    &:hover,
+    &:active {
+      width: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-y-rail-width);
+      > .ps-scrollbar-y {
+        width: map_get($theme, scrollbar-rail-scale-hover) * map_get($theme, scrollbar-y-rail-width);
+      }
+    }
 
     > .ps-scrollbar-y {
       @include scrollbar-default($theme);

--- a/src/css/themes.scss
+++ b/src/css/themes.scss
@@ -7,6 +7,7 @@ $ps-theme-default: (
   bar-container-hover-bg: $ps-bar-container-hover-bg,
   bar-hover-bg: $ps-bar-hover-bg,
   rail-hover-bg: $ps-rail-hover-bg,
+  scrollbar-rail-scale-hover: $ps-scrollbar-rail-scale-hover,
   scrollbar-x-rail-bottom: $ps-scrollbar-x-rail-bottom,
   scrollbar-x-rail-height: $ps-scrollbar-x-rail-height,
   scrollbar-x-bottom: $ps-scrollbar-x-bottom,

--- a/src/css/variables.scss
+++ b/src/css/variables.scss
@@ -11,6 +11,7 @@ $ps-bar-hover-bg: #999 !default;
 $ps-rail-hover-bg: #eee !default;
 
 // Sizes
+$ps-scrollbar-rail-scale-hover: 1 !default;
 $ps-scrollbar-x-rail-bottom: 3px !default;
 $ps-scrollbar-x-rail-height: 8px !default;
 $ps-scrollbar-x-bottom: 0 !default;


### PR DESCRIPTION
Many new scrollbars on Facebook/Twitter/etc now allow for scaling of the scrollbar on hover.  This PR adds the ability to set a hover scale size in the theme which will scale the X and Y rails when hovered.

You can view the changes by checking out the `custom-theme.html` or check out this video http://screencast.com/t/1Rg58TG8

I also added a `custom-theme.scss` used for the `custom-theme.html` example.  This example also now implements the hover scale behavior.

Fixes #514
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Perfect Scrollbar JSFiddle: https://jsfiddle.net/DanielApt/xv0rrxv3/
  - With jQuery: https://jsfiddle.net/DanielApt/gbfLazpx/
- [x] Refer to concerning issues if exist
