### PR TITLE
On keydown, check for e.isDefaultPrevented() [jquery] and e.defaultPrevented [native]

### DIFF
--- a/src/js/plugin/handler/keyboard.js
+++ b/src/js/plugin/handler/keyboard.js
@@ -40,7 +40,7 @@ function bindKeyboardHandler(element, i) {
   }
 
   i.event.bind(i.ownerDocument, 'keydown', function (e) {
-    if (e.isDefaultPrevented && e.isDefaultPrevented()) {
+    if (e.isDefaultPrevented && e.isDefaultPrevented() || e.defaultPrevented) {
       return;
     }
 


### PR DESCRIPTION
Event could be a native browser event, so we should also check for "defaultPrevented" if the jQuery props don't exist.
