### PR TITLE
Adding Ps.enable/disable to allow the Perfect-Scrollbar to be disabled temporarily and re-enabled later easily

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ container.scrollTop = 0;
 Ps.update(container);
 ```
 
+If you want to temporarily disable (but leave visible) the scrollbar, use
+`disable` (and `enable` to re-enable it later).
+
+```javascript
+Ps.disable(container);
+```
+Enabling the scroller again can easily be done by calling:
+```javascript
+Ps.enable(container);
+```
+
 You can also get information about how to use the plugin
 from code in the `examples` directory of the source tree.
 

--- a/examples/enable-disable.html
+++ b/examples/enable-disable.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>perfect-scrollbar example</title>
+    <link href="../dist/css/perfect-scrollbar.css" rel="stylesheet">
+    <script src="../dist/js/perfect-scrollbar.js"></script>
+    <style>
+      .contentHolder { position:relative; margin:0px auto; padding:0px; width: 600px; height: 400px; overflow: auto; }
+      .contentHolder .content { background-image: url('./azusa.jpg'); width: 1280px; height: 720px; }
+      .spacer { text-align:center }
+    </style>
+  </head>
+  <body>
+    <div id="Default" class="contentHolder">
+      <div class="content">
+      </div>
+    </div>
+    <p style='text-align: center'>
+      Width <input type='text' id='width' value='600'>
+      Height <input type='text' id='height' value='400'>
+      <button onclick='updateSize()'>Change!</button>
+    </p>
+    <p style='text-align: center;'>
+      <button onclick='disablePs()'>Disable</button>
+      <button onclick='enablePs()'>Enable</button>
+    </p>
+    <script>
+      var $ = document.querySelector.bind(document);
+      window.onload = function () {
+        Ps.initialize($('#Default'));
+      };
+      var updateSize = function () {
+        var width = parseInt($('#width').value, 10);
+        var height = parseInt($('#height').value, 10);
+        var container = $('#Default');
+        container.style.width = width + 'px';
+        container.style.height = height + 'px';
+        Ps.update(document.querySelector('#Default'));
+      };
+      var enablePs = function() {
+        Ps.enable(document.querySelector('#Default'));
+      };
+      var disablePs = function() {
+        Ps.disable(document.querySelector('#Default'));
+      };
+    </script>
+  </body>
+</html>
+

--- a/src/js/adaptor/jquery.js
+++ b/src/js/adaptor/jquery.js
@@ -20,6 +20,10 @@ function mountJQuery(jQuery) {
 
         if (command === 'update') {
           ps.update(this);
+        } else if (command === 'enable') {
+          ps.enable(this);
+        } else if (command === 'disable') {
+          ps.disable(this);
         } else if (command === 'destroy') {
           ps.destroy(this);
         }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3,9 +3,13 @@
 var destroy = require('./plugin/destroy');
 var initialize = require('./plugin/initialize');
 var update = require('./plugin/update');
+var enable = require('./plugin/enable');
+var disable = require('./plugin/disable');
 
 module.exports = {
   initialize: initialize,
   update: update,
-  destroy: destroy
+  destroy: destroy,
+  enable: enable,
+  disable: disable
 };

--- a/src/js/plugin/disable.js
+++ b/src/js/plugin/disable.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var cls = require('../lib/class');
+
+module.exports = function (element) {
+  cls.add(element, 'ps-disabled');
+};

--- a/src/js/plugin/enable.js
+++ b/src/js/plugin/enable.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var cls = require('../lib/class');
+
+
+module.exports = function (element) {
+  cls.remove(element, 'ps-disabled');
+};

--- a/src/js/plugin/handler/click-rail.js
+++ b/src/js/plugin/handler/click-rail.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('../../lib/helper');
+var cls = require('../../lib/class');
 var instances = require('../instances');
 var updateGeometry = require('../update-geometry');
 var updateScroll = require('../update-scroll');
@@ -15,6 +16,12 @@ function bindClickRailHandler(element, i) {
     i.event.bind(i.scrollbarY, 'click', stopPropagation);
   }
   i.event.bind(i.scrollbarYRail, 'click', function (e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
+
     var halfOfScrollbarLength = _.toInt(i.scrollbarYHeight / 2);
     var positionTop = i.railYRatio * (e.pageY - window.pageYOffset - pageOffset(i.scrollbarYRail).top - halfOfScrollbarLength);
     var maxPositionTop = i.railYRatio * (i.railYHeight - i.scrollbarYHeight);
@@ -36,6 +43,12 @@ function bindClickRailHandler(element, i) {
     i.event.bind(i.scrollbarX, 'click', stopPropagation);
   }
   i.event.bind(i.scrollbarXRail, 'click', function (e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
+
     var halfOfScrollbarLength = _.toInt(i.scrollbarXWidth / 2);
     var positionLeft = i.railXRatio * (e.pageX - window.pageXOffset - pageOffset(i.scrollbarXRail).left - halfOfScrollbarLength);
     var maxPositionLeft = i.railXRatio * (i.railXWidth - i.scrollbarXWidth);

--- a/src/js/plugin/handler/drag-scrollbar.js
+++ b/src/js/plugin/handler/drag-scrollbar.js
@@ -2,6 +2,7 @@
 
 var _ = require('../../lib/helper');
 var dom = require('../../lib/dom');
+var cls = require('../../lib/class');
 var instances = require('../instances');
 var updateGeometry = require('../update-geometry');
 var updateScroll = require('../update-scroll');
@@ -39,6 +40,11 @@ function bindMouseScrollXHandler(element, i) {
   };
 
   i.event.bind(i.scrollbarX, 'mousedown', function (e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
     currentPageX = e.pageX;
     currentLeft = _.toInt(dom.css(i.scrollbarX, 'left')) * i.railXRatio;
     _.startScrolling(element, 'x');
@@ -84,6 +90,11 @@ function bindMouseScrollYHandler(element, i) {
   };
 
   i.event.bind(i.scrollbarY, 'mousedown', function (e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
     currentPageY = e.pageY;
     currentTop = _.toInt(dom.css(i.scrollbarY, 'top')) * i.railYRatio;
     _.startScrolling(element, 'y');

--- a/src/js/plugin/handler/keyboard.js
+++ b/src/js/plugin/handler/keyboard.js
@@ -2,6 +2,7 @@
 
 var _ = require('../../lib/helper');
 var dom = require('../../lib/dom');
+var cls = require('../../lib/class');
 var instances = require('../instances');
 var updateGeometry = require('../update-geometry');
 var updateScroll = require('../update-scroll');
@@ -40,6 +41,11 @@ function bindKeyboardHandler(element, i) {
   }
 
   i.event.bind(i.ownerDocument, 'keydown', function (e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
     if ((e.isDefaultPrevented && e.isDefaultPrevented()) || e.defaultPrevented) {
       return;
     }

--- a/src/js/plugin/handler/mouse-wheel.js
+++ b/src/js/plugin/handler/mouse-wheel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var instances = require('../instances');
+var cls = require('../../lib/class');
 var updateGeometry = require('../update-geometry');
 var updateScroll = require('../update-scroll');
 
@@ -79,6 +80,11 @@ function bindMouseWheelHandler(element, i) {
   }
 
   function mousewheelHandler(e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      e.preventDefault();
+      return;
+    }
     var delta = getDeltaFromEvent(e);
 
     var deltaX = delta[0];

--- a/src/js/plugin/handler/native-scroll.js
+++ b/src/js/plugin/handler/native-scroll.js
@@ -1,10 +1,17 @@
 'use strict';
 
 var instances = require('../instances');
+var cls = require('../../lib/class');
 var updateGeometry = require('../update-geometry');
 
 function bindNativeScrollHandler(element, i) {
-  i.event.bind(element, 'scroll', function () {
+  i.event.bind(element, 'scroll', function (e) {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      e.preventDefault();
+      return;
+    }
+
     updateGeometry(element);
   });
 }

--- a/src/js/plugin/handler/selection.js
+++ b/src/js/plugin/handler/selection.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('../../lib/helper');
+var cls = require('../../lib/class');
 var instances = require('../instances');
 var updateGeometry = require('../update-geometry');
 var updateScroll = require('../update-scroll');
@@ -42,6 +43,12 @@ function bindSelectionHandler(element, i) {
 
   var isSelected = false;
   i.event.bind(i.ownerDocument, 'selectionchange', function () {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
+
     if (element.contains(getRangeNode())) {
       isSelected = true;
     } else {

--- a/src/js/plugin/handler/touch.js
+++ b/src/js/plugin/handler/touch.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var _ = require('../../lib/helper');
+var cls = require('../../lib/class');
 var instances = require('../instances');
+
 var updateGeometry = require('../update-geometry');
 var updateScroll = require('../update-scroll');
 
@@ -46,6 +48,11 @@ function bindTouchHandler(element, i, supportsTouch, supportsIePointer) {
   var inLocalTouch = false;
 
   function globalTouchStart() {
+    var currentClasses = cls.list(element);
+    if (currentClasses.indexOf("ps-disabled") !== -1) {
+      return;
+    }
+
     inGlobalTouch = true;
   }
   function globalTouchEnd() {
@@ -71,6 +78,11 @@ function bindTouchHandler(element, i, supportsTouch, supportsIePointer) {
   }
   function touchStart(e) {
     if (shouldHandle(e)) {
+      var currentClasses = cls.list(element);
+      if (currentClasses.indexOf("ps-disabled") !== -1) {
+        return;
+      }
+
       inLocalTouch = true;
 
       var touch = getTouch(e);


### PR DESCRIPTION
I needed a way to temporarily disable the scrolling on a PS container.
Calling .destroy and the re-initialising was causing the scroll area to go to the top (e.g. do a .scrollTop = 0), for some unknown reason, which ... even that was "workaroundable" I thought that it would be a lot more useful to just do a .preventDefault on the "wheel" event.

Then I'd found out that I can just add this into the Ps library, so that it would leave the scrollbars visible (can be hidden using the .ps-disabled class and some styles or styled as "disabled") and apparently this works best :)

So here is the MR, as following the contributing checklist:
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)

Example of how this is supposed to work (the fiddle would complain for missing the Ps.enable/disable, which is added in this PR): https://jsfiddle.net/11sqnr1q/5/

A working example can be found in:
./examples/enable-disable.html
- [x] Refer to concerning issues if exist

I've not tested the 'touch' handler and the 'jQuery' version of the plugin (despite that i'd exposed the enable/disable methods in the code).
