### PR TITLE
Defined dependencies for jspm

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,12 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },
+  "jspm": {
+    "main": "./index.js",
+    "dependencies": {
+      "jquery": "npm:jquery"
+    }
+  },
   "scripts": {
     "test": "gulp",
     "before-deploy": "gulp && gulp compress",


### PR DESCRIPTION
JSPM needs the dependencies defined in a particular format. If this is not done one would need to defined the dependencies manually. Also by not defining a jQuery version JSPM will use the version that is currently being used in the said project. JSPM will also handle the cases where jQuery is not being used just like any bundler.
