### PR TITLE
Touch scrolling bug

### DIFF
--- a/src/js/plugin/handler/touch.js
+++ b/src/js/plugin/handler/touch.js
@@ -128,6 +128,11 @@ function bindTouchHandler(element, i, supportsTouch, supportsIePointer) {
           return;
         }
 
+        if(!speed.x && !speed.y) {
+          clearInterval(easingLoop);
+          return;
+        }
+
         if (Math.abs(speed.x) < 0.01 && Math.abs(speed.y) < 0.01) {
           clearInterval(easingLoop);
           return;

--- a/src/js/plugin/handler/touch.js
+++ b/src/js/plugin/handler/touch.js
@@ -128,7 +128,7 @@ function bindTouchHandler(element, i, supportsTouch, supportsIePointer) {
           return;
         }
 
-        if(!speed.x && !speed.y) {
+        if (!speed.x && !speed.y) {
           clearInterval(easingLoop);
           return;
         }


### PR DESCRIPTION
Hi,

I noticed an issue on touch screen devices, when you make a touch without dragging (like a click). This reset the container scrollTop to the top. It seems to only happen when you touch directly after a scrollTop change (no other interaction done with the perfect-scrollbar container).

My solution might not be the ideal way to deal with it, but it prevents it from happening. Please tell me if you find a better solution, I don't have much time for it for now.

Basically, when we touch, it triggers [touchStart()](https://github.com/noraesae/perfect-scrollbar/blob/master/src/js/plugin/handler/touch.js#L72), `touchMove()` and then `touchEnd()` functions. `touchEnd()` uses a `speed` object to update the scrollTop value.
This speed object is created/updated by touchMove only when there is some time elapsed between 2 steps of moving, but in this case all events happens at the same time I guess so the `speed` object is not updated.
So when `touchEnd()` wants to update `scrollTop` with the speed value, we get `undefined` and it goes to 0.

I hope that's somewhat clear.
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Open the JSFiddle on a device with a touch screen and touch the container (without dragging)
  - JSFiddle showing the issue: https://jsfiddle.net/axc87w95/1/
- [ ] Refer to concerning issues if exist -- don't think there is an issue about that
