### PR TITLE
Add explicit void to typedef functions

### DIFF
--- a/perfect-scrollbar.d.ts
+++ b/perfect-scrollbar.d.ts
@@ -13,9 +13,9 @@ interface PerfectScrollbarOptions {
 }
 
 interface PerfectScrollbar {
-  initialize(container: HTMLElement, options?: PerfectScrollbarOptions);
-  update(container: HTMLElement);
-  destroy(container: HTMLElement);
+  initialize(container: HTMLElement, options?: PerfectScrollbarOptions): void;
+  update(container: HTMLElement): void;
+  destroy(container: HTMLElement): void;
 }
 
 interface JQuery {


### PR DESCRIPTION
Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Perfect Scrollbar JSFiddle: https://jsfiddle.net/DanielApt/xv0rrxv3/
  - With jQuery: https://jsfiddle.net/DanielApt/gbfLazpx/
- [ ] Refer to concerning issues if exist

It is needed if we use the noImplicitAny switch in the tsconfig.json file.
Otherwise the typescript compiler won't compile it.
Error messages caused by lack of explicit return types:

node_modules/perfect-scrollbar/perfect-scrollbar.d.ts(16,3):
error TS7010: 'initialize', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/perfect-scrollbar/perfect-scrollbar.d.ts(17,3):
error TS7010: 'update', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/perfect-scrollbar/perfect-scrollbar.d.ts(18,3):
error TS7010: 'destroy', which lacks return-type annotation, implicitly has an 'any' return type.