### PR TITLE
Jquery is not a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
   },
   "jspm": {
     "main": "./index.js",
-    "dependencies": {
-      "jquery": "npm:jquery"
-    }
+    "registry": "jspm"
   },
   "typings": "perfect-scrollbar.d.ts",
   "scripts": {


### PR DESCRIPTION
Jquery is not a dependency it is optional and should be treated as such.  Optionals will be part of 0.17 but that is still in beta.
Registry override will solve error #578