### PR TITLE
Replaced obj.constructor with Array.isArray

### DIFF
--- a/src/js/lib/helper.js
+++ b/src/js/lib/helper.js
@@ -10,7 +10,7 @@ var toInt = exports.toInt = function (x) {
 var clone = exports.clone = function (obj) {
   if (!obj) {
     return null;
-  } else if (obj.constructor === Array) {
+  } else if (Array.isArray(obj)) {
     return obj.map(clone);
   } else if (typeof obj === 'object') {
     var result = {};


### PR DESCRIPTION
Fixes #601 

This handles edge cases where a user is using something like PrototypeJS which overrides the default Array constructor which prevents perfect-scrollbar from working properly.