### PR TITLE
Avoid unnecessary ps-scroll-x/y events

### DIFF
--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -60,11 +60,11 @@ module.exports = function (element, axis, value) {
     element.dispatchEvent(createDOMEvent('ps-x-reach-end'));
   }
 
-  if (!lastTop) {
+  if (lastTop === undefined) {
     lastTop = element.scrollTop;
   }
 
-  if (!lastLeft) {
+  if (lastLeft === undefined) {
     lastLeft = element.scrollLeft;
   }
 

--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -84,12 +84,12 @@ module.exports = function (element, axis, value) {
     element.dispatchEvent(createDOMEvent('ps-scroll-right'));
   }
 
-  if (axis === 'top') {
+  if (axis === 'top' && value !== lastTop) {
     element.scrollTop = lastTop = value;
     element.dispatchEvent(createDOMEvent('ps-scroll-y'));
   }
 
-  if (axis === 'left') {
+  if (axis === 'left' && value !== lastLeft) {
     element.scrollLeft = lastLeft = value;
     element.dispatchEvent(createDOMEvent('ps-scroll-x'));
   }

--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -2,9 +2,6 @@
 
 var instances = require('./instances');
 
-var lastTop;
-var lastLeft;
-
 var createDOMEvent = function (name) {
   var event = document.createEvent("Event");
   event.initEvent(name, true, true);
@@ -60,37 +57,37 @@ module.exports = function (element, axis, value) {
     element.dispatchEvent(createDOMEvent('ps-x-reach-end'));
   }
 
-  if (lastTop === undefined) {
-    lastTop = element.scrollTop;
+  if (i.lastTop === undefined) {
+    i.lastTop = element.scrollTop;
   }
 
-  if (lastLeft === undefined) {
-    lastLeft = element.scrollLeft;
+  if (i.lastLeft === undefined) {
+    i.lastLeft = element.scrollLeft;
   }
 
-  if (axis === 'top' && value < lastTop) {
+  if (axis === 'top' && value < i.lastTop) {
     element.dispatchEvent(createDOMEvent('ps-scroll-up'));
   }
 
-  if (axis === 'top' && value > lastTop) {
+  if (axis === 'top' && value > i.lastTop) {
     element.dispatchEvent(createDOMEvent('ps-scroll-down'));
   }
 
-  if (axis === 'left' && value < lastLeft) {
+  if (axis === 'left' && value < i.lastLeft) {
     element.dispatchEvent(createDOMEvent('ps-scroll-left'));
   }
 
-  if (axis === 'left' && value > lastLeft) {
+  if (axis === 'left' && value > i.lastLeft) {
     element.dispatchEvent(createDOMEvent('ps-scroll-right'));
   }
 
-  if (axis === 'top' && value !== lastTop) {
-    element.scrollTop = lastTop = value;
+  if (axis === 'top' && value !== i.lastTop) {
+    element.scrollTop = i.lastTop = value;
     element.dispatchEvent(createDOMEvent('ps-scroll-y'));
   }
 
-  if (axis === 'left' && value !== lastLeft) {
-    element.scrollLeft = lastLeft = value;
+  if (axis === 'left' && value !== i.lastLeft) {
+    element.scrollLeft = i.lastLeft = value;
     element.dispatchEvent(createDOMEvent('ps-scroll-x'));
   }
 


### PR DESCRIPTION
I am a co-worker of @Avuthless and we fiddled with #607. 

## Our actual issue

We were listening to the `ps-scroll-y` event to hide a tooltip in case of scrolling. But, this approach collides with our call of `Ps.update()` which in turn raises `ps-scroll-y` (through `Ps.updateScoll()`) even if the use didn't really scroll.

The given fix is simply adding further conditions to only raise `ps-scroll-y` and `ps-scroll-x` if the scroll position really changed.

I am not sure if these missing conditions were on purpose. At least for us it solved the problems.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Perfect Scrollbar JSFiddle: https://jsfiddle.net/DanielApt/xv0rrxv3/
  - With jQuery: https://jsfiddle.net/DanielApt/gbfLazpx/
- [x] Refer to concerning issues if exist