### PR TITLE
Added style in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
     "before-deploy": "gulp && gulp compress",
     "release": "rm -rf dist && gulp && npm publish"
   },
+  "style": "./dist/css/perfect-scrollbar.min.css",
   "license": "MIT"
 }


### PR DESCRIPTION
Added style to package.json.

When installed via npm, a style property in package.json allows this module to be easily imported when using tools such as npm-sass or sass-module-importer.

Apparently the "style" key is not a standard, but it is a growing trend. Here's a StackOverflow thread on the subject: http://stackoverflow.com/questions/32037150/style-field-in-package-json

Resolves #605 