### PR TITLE
Fix ps-child overflow style check for Firefox

### DIFF
--- a/src/js/plugin/handler/mouse-wheel.js
+++ b/src/js/plugin/handler/mouse-wheel.js
@@ -62,7 +62,14 @@ function bindMouseWheelHandler(element, i) {
   function shouldBeConsumedByChild(deltaX, deltaY) {
     var child = element.querySelector('textarea:hover, select[multiple]:hover, .ps-child:hover');
     if (child) {
-      if (!window.getComputedStyle(child).overflow.match(/(scroll|auto)/)) {
+      var style = window.getComputedStyle(child);
+      var overflow = [
+        style.overflow,
+        style.overflowX,
+        style.overflowY
+      ].join('');
+
+      if (!overflow.match(/(scroll|auto)/)) {
         // if not scrollable
         return false;
       }


### PR DESCRIPTION
Hi,

We've run into a problem where mouse wheel events were not being consumed by element with `ps-child`. The problem seems to be in the check for overflow style of the child element.

When overflowX and overflowY are specified individually in Firefox, the computed style for overflow will be "", even though overflowY might be "auto" or "scroll". This is why all three overflow properties need to be checked: overflow, overflowX, and overflowY.

Hope you find this useful,
Amir
