### PR TITLE
Add env check to allow running on node.js

### DIFF
--- a/src/js/lib/helper.js
+++ b/src/js/lib/helper.js
@@ -73,7 +73,7 @@ exports.startScrolling = toggleScrolling(cls.add);
 exports.stopScrolling = toggleScrolling(cls.remove);
 
 exports.env = {
-  isWebKit: 'WebkitAppearance' in document.documentElement.style,
-  supportsTouch: (('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch),
-  supportsIePointer: window.navigator.msMaxTouchPoints !== null
+  isWebKit: typeof document !== 'undefined' && 'WebkitAppearance' in document.documentElement.style,
+  supportsTouch: typeof window !== 'undefined' && (('ontouchstart' in window) || window.DocumentTouch && document instanceof window.DocumentTouch),
+  supportsIePointer: typeof window !== 'undefined' && window.navigator.msMaxTouchPoints !== null
 };


### PR DESCRIPTION
The problem was that exports.env = {} evaluated unconditionally which causes ReferenceError if module was imported anywhere in frontend. This fix allows not to bother about module substitutes for universal (isomorphic) apps.

Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Perfect Scrollbar JSFiddle: https://jsfiddle.net/DanielApt/xv0rrxv3/
  - With jQuery: https://jsfiddle.net/DanielApt/gbfLazpx/
- [ ] Refer to concerning issues if exist
