### PR TITLE
More logical event sending order

### DIFF
--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -23,12 +23,10 @@ module.exports = function (element, axis, value) {
 
   if (axis === 'top' && value <= 0) {
     element.scrollTop = value = 0; // don't allow negative scroll
-    element.dispatchEvent(createDOMEvent('ps-y-reach-start'));
   }
 
   if (axis === 'left' && value <= 0) {
     element.scrollLeft = value = 0; // don't allow negative scroll
-    element.dispatchEvent(createDOMEvent('ps-x-reach-start'));
   }
 
   var i = instances.get(element);
@@ -42,7 +40,6 @@ module.exports = function (element, axis, value) {
     } else {
       element.scrollTop = value;
     }
-    element.dispatchEvent(createDOMEvent('ps-y-reach-end'));
   }
 
   if (axis === 'left' && value >= i.contentWidth - i.containerWidth) {
@@ -54,7 +51,6 @@ module.exports = function (element, axis, value) {
     } else {
       element.scrollLeft = value;
     }
-    element.dispatchEvent(createDOMEvent('ps-x-reach-end'));
   }
 
   if (i.lastTop === undefined) {
@@ -63,6 +59,16 @@ module.exports = function (element, axis, value) {
 
   if (i.lastLeft === undefined) {
     i.lastLeft = element.scrollLeft;
+  }
+
+  if (axis === 'top' && value !== i.lastTop) {
+    element.scrollTop = i.lastTop = value;
+    element.dispatchEvent(createDOMEvent('ps-scroll-y'));
+  }
+
+  if (axis === 'left' && value !== i.lastLeft) {
+    element.scrollLeft = i.lastLeft = value;
+    element.dispatchEvent(createDOMEvent('ps-scroll-x'));
   }
 
   if (axis === 'top' && value < i.lastTop) {
@@ -81,14 +87,19 @@ module.exports = function (element, axis, value) {
     element.dispatchEvent(createDOMEvent('ps-scroll-right'));
   }
 
-  if (axis === 'top' && value !== i.lastTop) {
-    element.scrollTop = i.lastTop = value;
-    element.dispatchEvent(createDOMEvent('ps-scroll-y'));
+  if (axis === 'top' && value <= 0) {
+    element.dispatchEvent(createDOMEvent('ps-y-reach-start'));
   }
 
-  if (axis === 'left' && value !== i.lastLeft) {
-    element.scrollLeft = i.lastLeft = value;
-    element.dispatchEvent(createDOMEvent('ps-scroll-x'));
+  if (axis === 'left' && value <= 0) {
+    element.dispatchEvent(createDOMEvent('ps-x-reach-start'));
   }
 
+  if (axis === 'top' && value >= i.contentHeight - i.containerHeight) {
+    element.dispatchEvent(createDOMEvent('ps-y-reach-end'));
+  }
+
+  if (axis === 'left' && value >= i.contentWidth - i.containerWidth) {
+    element.dispatchEvent(createDOMEvent('ps-x-reach-end'));
+  }
 };


### PR DESCRIPTION
When scrolling / swiping the events are sent in logical order (i.e. first comes the scroll events then the reach end events), but when setting the scroll position (through scrollTop for example) and calling update the event come in confusing order (first reach end event then scroll event).

This patch changes the order which the events are dispatched so that even in the latter case the events come in the order you would expect them to be.

If there was some logic for the events to be in the order they were then let me know, but at least this order makes more sense to me and removes extra checks for being at the end on scroll event from our application code. Since with current order when receiving scroll event we need to do some extra checks that are we still at end since we can't trust the reach end events.