### PR TITLE
Increase rounding error tolerance for full scroll

### DIFF
--- a/src/js/plugin/update-scroll.js
+++ b/src/js/plugin/update-scroll.js
@@ -36,7 +36,7 @@ module.exports = function (element, axis, value) {
   if (axis === 'top' && value >= i.contentHeight - i.containerHeight) {
     // don't allow scroll past container
     value = i.contentHeight - i.containerHeight;
-    if (value - element.scrollTop <= 1) {
+    if (value - element.scrollTop <= 2) {
       // mitigates rounding errors on non-subpixel scroll values
       value = element.scrollTop;
     } else {
@@ -48,7 +48,7 @@ module.exports = function (element, axis, value) {
   if (axis === 'left' && value >= i.contentWidth - i.containerWidth) {
     // don't allow scroll past container
     value = i.contentWidth - i.containerWidth;
-    if (value - element.scrollLeft <= 1) {
+    if (value - element.scrollLeft <= 2) {
       // mitigates rounding errors on non-subpixel scroll values
       value = element.scrollLeft;
     } else {


### PR DESCRIPTION
See PR #486. It seems that in some browsers and in certain cases, 2 rounding errors add up regarding in-browser scroll calculations, leading to a difference of 2 pixels instead of 1. Increasing the tolerance to 2px in does not seem to adversely affect perfect-scrollbar and fixes the issue.
Thanks for looking into this!