### PR TITLE
Check for existens of element.msMatchesSelector

### DIFF
--- a/src/js/lib/dom.js
+++ b/src/js/lib/dom.js
@@ -52,7 +52,7 @@ DOM.css = function (element, styleNameOrObject, styleValue) {
 DOM.matches = function (element, query) {
   if (typeof element.matches !== 'undefined') {
     return element.matches(query);
-  } else {
+  } else if (typeof element.msMatchesSelector !== 'undefined') {
     // must be IE11 and Edge
     return element.msMatchesSelector(query);
   }


### PR DESCRIPTION
PhantomJS 2 for example throws an error for not knowing element.msMatchesSelector. Just make it a little more secure.

Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `gulp` to make sure it builds and lints successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Perfect Scrollbar JSFiddle: https://jsfiddle.net/DanielApt/xv0rrxv3/
  - With jQuery: https://jsfiddle.net/DanielApt/gbfLazpx/
- [ ] Refer to concerning issues if exist
