### PR TITLE
Fix Scroll Propagation for Touchpads

### DIFF
--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -9,32 +9,21 @@ export default function(i) {
   let shouldPrevent = false;
 
   function shouldPreventDefault(deltaX, deltaY) {
-    const scrollTop = element.scrollTop;
-    if (deltaX === 0) {
-      if (!i.scrollbarYActive) {
-        return false;
-      }
-      if (
-        (scrollTop === 0 && deltaY > 0) ||
-        (scrollTop >= i.contentHeight - i.containerHeight && deltaY < 0)
-      ) {
-        return !i.settings.wheelPropagation;
-      }
+    const isTop = element.scrollTop === 0;
+    const isBottom = element.scrollTop + element.offsetHeight === element.scrollHeight;
+    const isLeft = element.scrollLeft === 0;
+    const isRight = element.scrollLeft + element.offsetWidth === element.offsetWidth;
+
+    let hitsBound;
+
+    // pick axis with primary direction
+    if (Math.abs(deltaY) > Math.abs(deltaX)) {
+      hitsBound = isTop || isBottom;
+    } else {
+      hitsBound = isLeft || isRight;
     }
 
-    const scrollLeft = element.scrollLeft;
-    if (deltaY === 0) {
-      if (!i.scrollbarXActive) {
-        return false;
-      }
-      if (
-        (scrollLeft === 0 && deltaX < 0) ||
-        (scrollLeft >= i.contentWidth - i.containerWidth && deltaX > 0)
-      ) {
-        return !i.settings.wheelPropagation;
-      }
-    }
-    return true;
+    return hitsBound ? !i.settings.wheelPropagation :  true;
   }
 
   function getDeltaFromEvent(e) {

--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -10,9 +10,11 @@ export default function(i) {
 
   function shouldPreventDefault(deltaX, deltaY) {
     const isTop = element.scrollTop === 0;
-    const isBottom = element.scrollTop + element.offsetHeight === element.scrollHeight;
+    const isBottom =
+      element.scrollTop + element.offsetHeight === element.scrollHeight;
     const isLeft = element.scrollLeft === 0;
-    const isRight = element.scrollLeft + element.offsetWidth === element.offsetWidth;
+    const isRight =
+      element.scrollLeft + element.offsetWidth === element.offsetWidth;
 
     let hitsBound;
 
@@ -23,7 +25,7 @@ export default function(i) {
       hitsBound = isLeft || isRight;
     }
 
-    return hitsBound ? !i.settings.wheelPropagation :  true;
+    return hitsBound ? !i.settings.wheelPropagation : true;
   }
 
   function getDeltaFromEvent(e) {


### PR DESCRIPTION
Original implementation caused choppy behavior when hitting container
bounds as it worked with delta===0 comparisons. This is perfectly fine
for wheels or browsers that do some sort of normalization (like Safari), but when `shouldPreventDefault` is feeded with raw touchpad data, moving the finger straight enough is unlikely, thus only a small percentage of scroll events were actually
propagated.

Improved implementation assumes the intended scroll axis by comparing
the absolute delta values of X and Y and propagates the events when
hitting the bounds on that axis.


- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
Works after `npm format`, didn't know that 
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - Video footage https://youtu.be/cNneEmjcBzY
- [x] Refer to concerning issues if exist
  - https://github.com/utatti/perfect-scrollbar/issues/639
