### PR TITLE
Make `wheelPropagation` work on Right Container Bound

### DIFF
--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -14,7 +14,7 @@ export default function(i) {
       element.scrollTop + element.offsetHeight === element.scrollHeight;
     const isLeft = element.scrollLeft === 0;
     const isRight =
-      element.scrollLeft + element.offsetWidth === element.offsetWidth;
+      element.scrollLeft + element.offsetWidth === element.scrollWidth;
 
     let hitsBound;
 


### PR DESCRIPTION
When I enabled wheelPropagation on the demo page, I noticed that it works only on top, bottom and left container bounds. I confused `scrollWidth` with `offsetWidth` for `isRight` calculation. This PR fixes this.