### PR TITLE
Enable `wheelPropagation` on Demo Page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -113,7 +113,9 @@ button.addEventListener('click', () => {
     var heightInput = $('height');
     var button = $('button');
 
-    var ps = new PerfectScrollbar(demoDiv);
+    var ps = new PerfectScrollbar(demoDiv, {
+      wheelPropagation: true
+    });
 
     button.addEventListener('click', function () {
       demoDiv.style.width = (widthInput.value || 600) + 'px';

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,9 @@
 
         <h2 class="subtitle">Code</h2>
         <pre class="prettyprint">
-const ps = new PerfectScrollbar(demoDiv);
+const ps = new PerfectScrollbar(demoDiv, {
+  wheelPropagation: true
+});
 
 button.addEventListener('click', () => {
   demoDiv.style.width = `${widthInput.value}px`;


### PR DESCRIPTION
As propagation is the default behavior in native scroll containers, I think
this will increase the perceived quality of the library when people try it out
on the Demo Page.