### PR TITLE
Fix RTL Support (#689)

### DIFF
--- a/css/perfect-scrollbar.css
+++ b/css/perfect-scrollbar.css
@@ -88,6 +88,11 @@
   position: absolute;
 }
 
+.ps--rtl > .ps__rail-y > .ps__thumb-y {
+  left: 2px;
+  right: unset;
+}
+
 .ps__rail-x:hover > .ps__thumb-x,
 .ps__rail-x:focus > .ps__thumb-x,
 .ps__rail-x.ps--clicking .ps__thumb-x {

--- a/examples/rtl-update.html
+++ b/examples/rtl-update.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link href="../css/perfect-scrollbar.css" rel="stylesheet">
+    <script src="../dist/perfect-scrollbar.js"></script>
+    <style>
+    #container {
+      position: relative;
+      margin: 0px auto;
+      padding: 0px;
+      width: 600px;
+      height: 400px;
+      overflow: auto;
+    }
+    #container .content {
+      background-image: url('./assets/azusa.jpg');
+      width: 1280px;
+      height: 720px;
+    }
+
+    #flip {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      margin-top: 10px;
+    }
+
+    body {
+      direction: rtl;
+    }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div class="content">
+      </div>
+    </div>
+    <div id="flip">
+      <button onclick="toggleRtl(); ps.update()">Turn RTL Off</button>
+    </div>
+    <script>
+      var ps = new PerfectScrollbar('#container');
+
+      function toggleRtl() {
+        var button = document.getElementById('flip').firstElementChild;
+        var body = document.body;
+
+      if (getComputedStyle(body).direction === 'rtl') {
+          body.style.direction = 'ltr';
+          button.textContent = 'Turn RTL On';
+        } else {
+          body.style.direction = 'rtl';
+          button.textContent = 'Turn RTL Off';
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/rtl.html
+++ b/examples/rtl.html
@@ -24,7 +24,6 @@
     </style>
   </head>
   <body>
-    <center><b>CURRENTLY NOT WORKING</b></center>
     <div id="container">
       <div class="content">
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,10 @@ export default class PerfectScrollbar {
     const blur = () => element.classList.remove(cls.state.focus);
 
     this.isRtl = CSS.get(element).direction === 'rtl';
+    if (this.isRtl) {
+      element.classList.add(cls.state.rtl);
+    }
+
     this.isNegativeScroll = (() => {
       const originalScrollLeft = element.scrollLeft;
       let result = null;
@@ -117,6 +121,7 @@ export default class PerfectScrollbar {
     this.scrollbarYTop = null;
     const railYStyle = CSS.get(this.scrollbarYRail);
     this.scrollbarYRight = parseInt(railYStyle.right, 10);
+
     if (isNaN(this.scrollbarYRight)) {
       this.isScrollbarYUsingRight = false;
       this.scrollbarYLeft = toInt(railYStyle.left);
@@ -161,6 +166,14 @@ export default class PerfectScrollbar {
   update() {
     if (!this.isAlive) {
       return;
+    }
+
+    // Reevaluate RTL status
+    this.isRtl = CSS.get(this.element).direction === 'rtl';
+    if (this.isRtl) {
+      this.element.classList.add(cls.state.rtl);
+    } else {
+      this.element.classList.remove(cls.state.rtl);
     }
 
     // Recalcuate negative scrollLeft adjustment

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,6 @@ export default class PerfectScrollbar {
     this.scrollbarYTop = null;
     const railYStyle = CSS.get(this.scrollbarYRail);
     this.scrollbarYRight = parseInt(railYStyle.right, 10);
-
     if (isNaN(this.scrollbarYRight)) {
       this.isScrollbarYUsingRight = false;
       this.scrollbarYLeft = toInt(railYStyle.left);

--- a/src/lib/class-names.js
+++ b/src/lib/class-names.js
@@ -9,6 +9,7 @@ const cls = {
     focus: 'ps--focus',
     clicking: 'ps--clicking',
     active: x => `ps--active-${x}`,
+    rtl: 'ps--rtl',
     scrolling: x => `ps--scrolling-${x}`,
   },
 };

--- a/src/update-geometry.js
+++ b/src/update-geometry.js
@@ -128,7 +128,8 @@ function updateCss(element, i) {
         i.contentWidth -
         (i.negativeScrollAdjustment + element.scrollLeft) -
         i.scrollbarYRight -
-        i.scrollbarYOuterWidth;
+        i.scrollbarYOuterWidth -
+        9;
     } else {
       yRailOffset.right = i.scrollbarYRight - element.scrollLeft;
     }


### PR DESCRIPTION
Fixes rtl.html, and also adds a new example (examples/rtl-update.html) to show updating RTL after the initial creation of the scrollbar. Also tested in an actual use case which was previously infinite-scrolling to the right in Chrome.

Couple of items to call out:

- Inspired by #744 :)
- RTL felt more like a status than a sub-element for CSS purposes, but then I don't use BEM
- This does not include [line 84 of Ahmad's changes](https://github.com/utatti/perfect-scrollbar/pull/744/files#diff-9f8d3ecb2771fa202f724209c5d0fdb0R84), as I couldn't identify a need for that change (or in fact any behavioral difference with it)
- I'm not 100% comfortable with the magic number 9, but figured someone else more familiar with the project might be able to quickly identify it faster than me digging around :)

Please let me know if you have any questions.

- [✓] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [✓] Run `npm test` to make sure it formats and build successfully
- [✓] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [✓] Refer to concerning issues if exist
