### PR TITLE
update scrollbar position and sizing values (in the PS instance) immediately when the scrollbar becomes inactive

### DIFF
--- a/src/update-geometry.js
+++ b/src/update-geometry.js
@@ -44,6 +44,8 @@ export default function(i) {
     );
   } else {
     i.scrollbarXActive = false;
+    i.scrollbarXWidth = 0;
+    i.scrollbarXLeft = 0;
   }
 
   if (
@@ -64,6 +66,8 @@ export default function(i) {
     );
   } else {
     i.scrollbarYActive = false;
+    i.scrollbarYHeight = 0;
+    i.scrollbarYTop = 0;
   }
 
   if (i.scrollbarXLeft >= i.railXWidth - i.scrollbarXWidth) {
@@ -79,16 +83,12 @@ export default function(i) {
     element.classList.add(cls.state.active('x'));
   } else {
     element.classList.remove(cls.state.active('x'));
-    i.scrollbarXWidth = 0;
-    i.scrollbarXLeft = 0;
     element.scrollLeft = 0;
   }
   if (i.scrollbarYActive) {
     element.classList.add(cls.state.active('y'));
   } else {
     element.classList.remove(cls.state.active('y'));
-    i.scrollbarYHeight = 0;
-    i.scrollbarYTop = 0;
     element.scrollTop = 0;
   }
 }


### PR DESCRIPTION
Thank you very much for your contribution! Please make sure the followings
are checked.

- [X] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [X] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [X] Refer to concerning issues if exist

This PR addresses the scenario of using perfect-scrollbar with an Angular app and calling ps.update() in the callback of an Observable that is omitted when the size of a content pane changes. For some reason (I spent hours looking into it and still don't know why), one of our scrollbars does not update properly when its associated content pane increases to more than the scrollWidth of the content (the scrollbar is not needed anymore, but it still shows up).

Unfortunately, I am cannot  create a demo jsfiddle since it would be impossible to do so without revealing proprietary code.