### PR TITLE
Prefix mozMatchesSelector added

### DIFF
--- a/src/lib/dom.js
+++ b/src/lib/dom.js
@@ -8,6 +8,7 @@ const elMatches =
   typeof Element !== 'undefined' &&
   (Element.prototype.matches ||
     Element.prototype.webkitMatchesSelector ||
+    Element.prototype.mozMatchesSelector ||
     Element.prototype.msMatchesSelector);
 
 export function matches(element, query) {


### PR DESCRIPTION
Firefox had until Version 34 a prefix for element.matches.
https://developer.mozilla.org/en-US/docs/Web/API/Element/matches

Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Run `npm test` to make sure it formats and build successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [ ] Refer to concerning issues if exist
