### PR TITLE
fix: IE issue with scrollWidth when zoom out

### DIFF
--- a/src/update-geometry.js
+++ b/src/update-geometry.js
@@ -6,9 +6,19 @@ import { toInt } from './lib/util';
 export default function(i) {
   const element = i.element;
 
+  var scrollWidth = element.scrollWidth;
+  var clientWidth = element.clientWidth;
+  var boundingClientWidth = element.getBoundingClientRect().width;
+  var isOverflowing =
+    scrollWidth > clientWidth && boundingClientWidth === clientWidth;
+  var difference = scrollWidth - clientWidth;
+
   i.containerWidth = element.clientWidth;
   i.containerHeight = element.clientHeight;
-  i.contentWidth = element.scrollWidth;
+  i.contentWidth =
+    isOverflowing && difference === 1
+      ? boundingClientWidth
+      : element.scrollWidth;
   i.contentHeight = element.scrollHeight;
 
   if (!element.contains(i.scrollbarXRail)) {


### PR DESCRIPTION
By adding a check to getBoundingClientRect() width, in update-geometry(). 

Fix issue mdbootstrap/perfect-scrollbar#115 
Thanks!