### PR TITLE
Fix demo page url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I hope you love it!
 
 ## Demo
 
-It's on the [GitHub Pages](http://utatti.github.com/perfect-scrollbar/).
+It's on the [GitHub Pages](http://utatti.github.io/perfect-scrollbar/).
 
 ## Table of Contents
 


### PR DESCRIPTION
fix the demo page url from `github.com` to `github.io` which is a valid github page url.
