### PR TITLE
Corrected scrollLeft => scrollWidth

### DIFF
--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -90,7 +90,7 @@ export default function(i) {
             return true;
           }
         }
-        const maxScrollLeft = cursor.scrollLeft - cursor.clientWidth;
+        const maxScrollLeft = cursor.scrollWidth - cursor.clientWidth;
         if (maxScrollLeft > 0) {
           if (
             !(cursor.scrollLeft === 0 && deltaX < 0) &&


### PR DESCRIPTION
While reading the code I found an asymmetry in mouse-wheel.js that looks like a bug. The maximal vertical scroll value is computed as  `cursor.scrollHeight - cursor.clientHeight`, but the maximal horizontal value is `cursor.scrollLeft - cursor.clientWidth`. I assume it should be `cursor.scrollWidth - cursor.clientWidth`.