### PR TITLE
Make reversing axis with shift key to be executed only on windows (OS X supports natively)

### DIFF
--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -50,10 +50,14 @@ export default function(i) {
       deltaX = 0;
       deltaY = e.wheelDelta;
     }
-
-    if (e.shiftKey) {
-      // reverse axis with shift key
-      return [-deltaY, -deltaX];
+    
+    // Reverse axis with shift key should be executed only on windows
+    var ua = window.navigator.userAgent;
+    if (ua.indexOf('Windows') > 0) {
+      if (e.shiftKey) {
+        // reverse axis with shift key
+        return [-deltaY, -deltaX];
+      }
     }
     return [deltaX, deltaY];
   }


### PR DESCRIPTION
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [JSFiddle - change axis on shiftkey works well on both Mac & Windows](https://jsfiddle.net/dyvL31r6/3467/)
- [x] Refer to concerning issues if exist
 - Issue mdbootstrap/perfect-scrollbar#104


Reverse axis on shift key is currently not working on OS X

OS X supports reversing natively, so they don't need the manual modification
So I changed the code to reverse delta only on Windows