### PR TITLE
Added missing properties in type definition

### DIFF
--- a/types/perfect-scrollbar.d.ts
+++ b/types/perfect-scrollbar.d.ts
@@ -21,6 +21,41 @@ declare class PerfectScrollbar {
   update(): void;
   destroy(): void;
 
+  containerHeight: number;
+  containerWidth: number;
+  contentHeight: number;
+  contentWidth: number;
+  element: HTMLElement;
+  isAlive: boolean;
+  isNegativeScroll: boolean;
+  isRtl: boolean;
+  isScrollbarXUsingBottom: boolean;
+  isScrollbarYUsingBottom: boolean;
+  lastScrollLeft: boolean;
+  lastScrollTop: boolean;
+  negativeScrollAdjustment: number;
+  railBorderXWidth: number;
+  railBorderYWidth: number;
+  railXMarginWidth: number;
+  railXRatio: number;
+  railXWidth: number;
+  railYHeight: number;
+  railYMarginHeight: number;
+  railYRatio: number;
+  scrollbarX: HTMLElement;
+  scrollbarXActive: boolean;
+  scrollbarXBottom: number;
+  scrollbarXLeft: number;
+  scrollbarXRail: HTMLElement;
+  scrollbarXWidth: number;
+  scrollbarY: HTMLElement;
+  scrollbarYActive: boolean;
+  scrollbarYHeight: number;
+  scrollbarYOuterWidth?: number;
+  scrollbarYRail: HTMLElement;
+  scrollbarYRight: number;
+  scrollbarYTop: number;
+  settings: PerfectScrollbar.Options;
   reach: { x: 'start' | 'end' | null, y: 'start' | 'end' | null };
 }
 


### PR DESCRIPTION
Added missing properties in type definition (perfect-scrollbar.d.ts)

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [ ] Refer to concerning issues if exist
