### PR TITLE
Update perfect-scrollbar.d.ts

### DIFF
--- a/types/perfect-scrollbar.d.ts
+++ b/types/perfect-scrollbar.d.ts
@@ -16,7 +16,7 @@ declare namespace PerfectScrollbar {
 }
 
 declare class PerfectScrollbar {
-  constructor(element: string | HTMLElement, options?: PerfectScrollbar.Options);
+  constructor(element: string | Element, options?: PerfectScrollbar.Options);
 
   update(): void;
   destroy(): void;


### PR DESCRIPTION
Better compatibility with parent class `Element` instead of `HTMLElement`
If you use `Vue.js`,you know the type of `$el` is `Element`,however,the `Element` is not assignable to parameter of type `string | HTMLElement`
