### PR TITLE
Support custom class for PerfectScrollbar container

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,19 @@ that Y axis scroll bar is not enabled just because of a few pixels.
 
 **Default**: `0`
 
+### `wrapperClass {String?}`
+
+The class that will be applied to the container element to enable styling of the
+`PerfectScrollbar` scrollbar elements. This is useful when pre-existing class definitions
+in your application conflict with the default `PerfectScrollbar` class and alter the
+plugin's look and feel.
+
+⚠️ **Warning**: Overwriting this setting will cancel most of the effects of the CSS
+provided with the library. You will have to write your own CSS to match the
+`PerfectScrollbar` element classes, [using this file as a template](https://github.com/mdbootstrap/perfect-scrollbar/blob/master/css/perfect-scrollbar.css).
+
+**Default**: `'ps'`
+
 ## Events
 
 perfect-scrollbar dispatches custom events.

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const defaultSettings = () => ({
   useBothWheelAxes: false,
   wheelPropagation: true,
   wheelSpeed: 1,
+  wrapperClass: cls.main,
 });
 
 const handlers = {
@@ -47,12 +48,12 @@ export default class PerfectScrollbar {
 
     this.element = element;
 
-    element.classList.add(cls.main);
-
     this.settings = defaultSettings();
     for (const key in userSettings) {
       this.settings[key] = userSettings[key];
     }
+
+    element.classList.add(this.settings.wrapperClass);
 
     this.containerWidth = null;
     this.containerHeight = null;

--- a/types/perfect-scrollbar.d.ts
+++ b/types/perfect-scrollbar.d.ts
@@ -12,6 +12,7 @@ declare namespace PerfectScrollbar {
     useBothWheelAxes?: boolean;
     wheelPropagation?: boolean;
     wheelSpeed?: number;
+    wrapperClass?: string;
   }
 }
 


### PR DESCRIPTION
I'm opening this to partially solve mdbootstrap/perfect-scrollbar#67 

I've had a look through the source code and creating a setting that can universally extend [the default class names](https://github.com/mdbootstrap/perfect-scrollbar/blob/b129f50590ca470394413c5c02a597d9114868df/src/lib/class-names.js#L1-L15) is absolutely too much of a hassle, since it would require passing around the user setting (merged with `cls`) into all the places where it's used.

It was, however, quite straightforward to support a single custom class for the container element, which basically allows users to replace `'ps'` with a class of their choosing.

This would mean any styles included in [the default CSS file](https://github.com/mdbootstrap/perfect-scrollbar/blob/master/css/perfect-scrollbar.css) will stop working, but I've added a clear warning for that in the `README.md` file and, hopefully, someone else might come up with a way to export an SCSS/LESS mixin that will allow people to regenerate the CSS without too much hassle.

Regarding the pull request _per se_, please note that I am only including the changes related to the task itself. I would leave the task of updating the version and rebuilding the `dist` folder to you when you decide to merge this.

I was not able, however, to work directly on your `master` branch because of a lot of outdated dependencies (basically `prettier` was screaming at me from the first run of `npm test`). I had to update the dependencies on my local environment in order to be able to work and test the feature.

I did not, however, include the changes I made to update the dependencies - I think that you, as the maintainer, should do this. You can [have a look at my `update-deps` branch here](https://github.com/mdbootstrap/perfect-scrollbar/compare/master...tibineagu:update-deps?expand=1). If you're ok with that, we can open another PR and merge that before this one.