### PR TITLE
Added touchMove event progress check before cancelling.

### DIFF
--- a/src/handlers/touch.js
+++ b/src/handlers/touch.js
@@ -165,7 +165,7 @@ export default function(i) {
         startTime = currentTime;
       }
 
-      if (shouldPrevent(differenceX, differenceY)) {
+      if (shouldPrevent(differenceX, differenceY) && e.cancelable) {
         e.preventDefault();
       }
     }


### PR DESCRIPTION
Fixing intervention message

> Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted

**Use case:**
 When multiple scroll / touch events occur during fast scrolling.

**Scenario:** 
{ suppressScrollY: true }