### PR TITLE
Add { passive: false } for event listeners

### DIFF
--- a/src/lib/event-manager.js
+++ b/src/lib/event-manager.js
@@ -9,7 +9,7 @@ class EventElement {
       this.handlers[eventName] = [];
     }
     this.handlers[eventName].push(handler);
-    this.element.addEventListener(eventName, handler, false);
+    this.element.addEventListener(eventName, handler, { passive: false });
   }
 
   unbind(eventName, target) {
@@ -17,7 +17,7 @@ class EventElement {
       if (target && handler !== target) {
         return true;
       }
-      this.element.removeEventListener(eventName, handler, false);
+      this.element.removeEventListener(eventName, handler, { passive: false });
       return false;
     });
   }


### PR DESCRIPTION
- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [x] Refer to concerning issues if exist

Referring mdbootstrap/perfect-scrollbar#53 mdbootstrap/perfect-scrollbar#74 

Add passive option for event listeners to avoid Chrome Violation warnings
```
[Violation] Added non-passive event listener to a scroll-blocking <some> event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952
```