### PR TITLE
Fix: scroll bar keeps scrolling down exceeding contents length (#920)

### DIFF
--- a/src/update-geometry.js
+++ b/src/update-geometry.js
@@ -8,8 +8,8 @@ export default function(i) {
   const roundedScrollTop = Math.floor(element.scrollTop);
   const rect = element.getBoundingClientRect();
 
-  i.containerWidth = Math.ceil(rect.width);
-  i.containerHeight = Math.ceil(rect.height);
+  i.containerWidth = Math.floor(rect.width);
+  i.containerHeight = Math.floor(rect.height);
   i.contentWidth = element.scrollWidth;
   i.contentHeight = element.scrollHeight;
 

--- a/src/update-geometry.js
+++ b/src/update-geometry.js
@@ -8,8 +8,9 @@ export default function(i) {
   const roundedScrollTop = Math.floor(element.scrollTop);
   const rect = element.getBoundingClientRect();
 
-  i.containerWidth = Math.floor(rect.width);
-  i.containerHeight = Math.floor(rect.height);
+  i.containerWidth = Math.round(rect.width);
+  i.containerHeight = Math.round(rect.height);
+
   i.contentWidth = element.scrollWidth;
   i.contentHeight = element.scrollHeight;
 


### PR DESCRIPTION
Please check my PR, i think that cause of this bug is difference beetween browser height calculations when container size is not an integer value and calculation in code.
Im not quite sure, but according to this warning in MDN:

[https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight)

> This property will round the value to an integer. If you need a fractional value, use Element.getBoundingClientRect().

its possible that browser also makes **floor** when doing calculations for display, because pixels are integers :)

Thank you very much for your contribution! Please make sure the followings
are checked.

- [ ] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Run `npm test` to make sure it formats and build successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [ ] Refer to concerning issues if exist

