### PR TITLE
Fix: unable zoom in mobile

### DIFF
--- a/src/handlers/touch.js
+++ b/src/handlers/touch.js
@@ -65,7 +65,7 @@ export default function(i) {
     if (e.pointerType && e.pointerType === 'pen' && e.buttons === 0) {
       return false;
     }
-    if (e.targetTouches && e.targetTouches.length === 1) {
+    if (e.touches && e.touches.length === 1) {
       return true;
     }
     if (


### PR DESCRIPTION
If we have touches in different containers zoom isn't working.
Try to zoom when fingers at the different pictures here https://jsfiddle.net/od4j2tL3/

See also:
https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/touches
https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/targetTouches


