### PR TITLE
Fix scrolling with useBothWheelAxes when both scrollbars are active

### DIFF
--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -116,7 +116,10 @@ export default function(i) {
     }
 
     let shouldPrevent = false;
-    if (!i.settings.useBothWheelAxes || (i.scrollbarYActive && i.scrollbarXActive)) {
+    if (
+      !i.settings.useBothWheelAxes ||
+      (i.scrollbarYActive && i.scrollbarXActive)
+    ) {
       // deltaX will only be used for horizontal scrolling and deltaY will
       // only be used for vertical scrolling - this is the default
       element.scrollTop -= deltaY * i.settings.wheelSpeed;

--- a/src/handlers/mouse-wheel.js
+++ b/src/handlers/mouse-wheel.js
@@ -116,7 +116,7 @@ export default function(i) {
     }
 
     let shouldPrevent = false;
-    if (!i.settings.useBothWheelAxes) {
+    if (!i.settings.useBothWheelAxes || (i.scrollbarYActive && i.scrollbarXActive)) {
       // deltaX will only be used for horizontal scrolling and deltaY will
       // only be used for vertical scrolling - this is the default
       element.scrollTop -= deltaY * i.settings.wheelSpeed;


### PR DESCRIPTION
Scrolling with mousewheel doesn't work when using `useBothWheelAxes` with two active scrollbars.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/spaknjgq/)
- [x] Refer to concerning issues if exist
