### PR TITLE
check if activeElement.contentDocument is null

### DIFF
--- a/src/handlers/keyboard.js
+++ b/src/handlers/keyboard.js
@@ -54,7 +54,7 @@ export default function(i) {
       ? document.activeElement
       : i.ownerDocument.activeElement;
     if (activeElement) {
-      if (activeElement.tagName === 'IFRAME') {
+      if (activeElement.tagName === 'IFRAME' && activeElement.contentDocument) {
         activeElement = activeElement.contentDocument.activeElement;
       } else {
         // go deeper if element is a webcomponent


### PR DESCRIPTION
contentDocument can be null if an iframe and the iframe's parent document are not in the same origin.
I cannot reproduce this on JSFiddle, but I'm getting a bunch of error logs from Sentry on this line. 
It started to happen when we've added [one tap Google sign in](https://developers.google.com/identity/one-tap/web) on our website, which depends on an iframe embedding a document from Google.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/contentDocument

Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [ ] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [ ] Refer to concerning issues if exist
