### PR TITLE
Fix: "Cannot read property 'scrollTop' of null" (#835)

### DIFF
--- a/src/handlers/touch.js
+++ b/src/handlers/touch.js
@@ -189,6 +189,11 @@ export default function(i) {
           return;
         }
 
+        if (!i.element) {
+          clearInterval(easingLoop);
+          return;
+        }
+
         applyTouchMove(speed.x * 30, speed.y * 30);
 
         speed.x *= 0.8;


### PR DESCRIPTION
Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - i.element might be destroyed before the timer is up, which led to the error, see the stack trace below
- [x] Refer to concerning issues if exist
  - [Cannot read property 'scrollTop' of null #835](https://github.com/mdbootstrap/perfect-scrollbar/issues/835)

<pre>
TypeError: Cannot read property 'scrollTop' of null\n    
at updateGeometry (...bundle.js:9556:59)\n    
at applyTouchMove (...bundle.js:9605:505)\n   
at ...bundle.js:9617:221
</pre>

and we are getting 31.1K this error every hour
![image](https://user-images.githubusercontent.com/20979257/95251159-22598a80-07e9-11eb-83dc-facf200ee9e1.png)

I'd expect more of this error in other places such as https://github.com/mdbootstrap/perfect-scrollbar/blob/master/src/index.js#L203, a quick fix is to modify as below, but that defeats the purpose of using `isAlive`, please advice.
<pre>
diff --git a/src/index.js b/src/index.js
index 451cd64..b4c830a 100644
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ export default class PerfectScrollbar {
   }
 
   onScroll(e) {
-    if (!this.isAlive) {
+    if (!this.isAlive || !this.element) {
       return;
     }
</pre>