### PR TITLE
Fix #968: Do not write to event[pageY]

### DIFF
--- a/src/handlers/drag-thumb.js
+++ b/src/handlers/drag-thumb.js
@@ -53,11 +53,12 @@ function bindMouseScrollHandler(
   let scrollBy = null;
 
   function mouseMoveHandler(e) {
+    let pageY_ = e[pageY];
     if (e.touches && e.touches[0]) {
-      e[pageY] = e.touches[0].pageY;
+      pageY_ = e.touches[0].pageY;
     }
     element[scrollTop] =
-      startingScrollTop + scrollBy * (e[pageY] - startingMousePageY);
+      startingScrollTop + scrollBy * (pageY_ - startingMousePageY);
     addScrollingClass(i, y);
     updateGeometry(i);
 
@@ -75,10 +76,11 @@ function bindMouseScrollHandler(
 
   function bindMoves(e, touchMode) {
     startingScrollTop = element[scrollTop];
+    let pageY_ = e[pageY];
     if (touchMode && e.touches) {
-      e[pageY] = e.touches[0].pageY;
+      pageY_ = e.touches[0].pageY;
     }
-    startingMousePageY = e[pageY];
+    startingMousePageY = pageY_;
     scrollBy =
       (i[contentHeight] - i[containerHeight]) /
       (i[railYHeight] - i[scrollbarYHeight]);


### PR DESCRIPTION
This fixes mdbootstrap/perfect-scrollbar#33, by not writing to read-only property of event.

The code is from mdbootstrap/Tailwind-Elements#969 but cleaned up, only to contain the needed fix. Also updated for the latest master version.

---

Thank you very much for your contribution! Please make sure the followings
are checked.

- [x] Read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Run `npm test` to make sure it formats and build successfully
- [x] Provide the scenario this PR will address(some JSFiddles will be perfect)
  - [perfect-scrollbar JSFiddle](https://jsfiddle.net/utatti/dyvL31r6/)
- [x] Refer to concerning issues if exist


