### PR TITLE
Added instructions for setting up component & site rendering using Node & EJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,45 @@ Alternatively, you can import it in the following way (bundler version):
 
 ```
 import 'tw-elements';
+
+##### NPM/EXPRESS & Middleware for EJS
+
+1. Before starting the project make sure to install [Node.js (LTS)](https://nodejs.org/en/ 'Node.js (LTS)') and [TailwindCSS](https://tailwindcss.com/ 'TailwindCSS').
+
+2. Run the following command to install the package via NPM:
+
+```
+npm install tw-elements
+```
+
+3. Tailwind Elements is a plugin and should be included inside the **tailwind.config.js** file. It is also recommended to extend the content array with a js file that loads dynamic component classes:
+
+```javascript
+module.exports = {
+  content: ['./src/**/*.{html,js}', './node_modules/tw-elements/dist/js/**/*.js'],
+  plugins: [require('tw-elements/dist/plugin')],
+};
+```
+
+4. When using Tailwind Element to render EJS, we need to set up the plugin middleware. Some components will require Node to read the packaged Javascript file to function. In order to make sure express gives Node access to the file, you will need to add the folder to your main server file:
+
+```
+app.use(express.static('ROOT-PATH/tw-elements/dist/js'));
+```
+
+5.  Dynamic components will work after adding the js file to the bottom of your EJS body:
+
+```
+<script src="./TW-ELEMENTS-PATH/dist/js/index.min.js"></script>
+```
+
+Alternatively, you can import it in the following way (bundler version):
+
+```
+import 'tw-elements';
+```
+
+
 ```
 
 ##### MDB GO / CLI


### PR DESCRIPTION
This is a pull request to add instructions to the README.md on how to get Node to be able to render EJS pages that include the Javascript some of the components require. The hope is that if this gets merged, these instructions get added to the website as well. While the fix is very simple, it may not come across as obvious to beginners who are learning to code and may be having their first framework experience with Tailwind Libraries.