### PR TITLE
Remove doctype declaration from svg example

### DIFF
--- a/site/content/docs/standard/components/social-buttons/index.html
+++ b/site/content/docs/standard/components/social-buttons/index.html
@@ -156,8 +156,6 @@ menu:
     </svg>
 
     <!-- Telegram -->
-    <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
     <svg
       class="h-5 w-5"
       fill="currentColor"
@@ -397,8 +395,6 @@ menu:
         </svg>
 
         <!-- Telegram -->
-        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
         <svg
           class="h-5 w-5"
           fill="currentColor"
@@ -739,8 +735,6 @@ menu:
     </svg>
 
     <!-- Telegram -->
-    <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-    <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
     <svg
       class="h-7 w-7"
       fill="currentColor"
@@ -1000,8 +994,6 @@ menu:
         </svg>
 
         <!-- Telegram -->
-        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-        <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
         <svg
           class="h-7 w-7"
           fill="currentColor"
@@ -1409,8 +1401,6 @@ menu:
       data-te-ripple-color="light"
       class="mb-2 inline-block rounded px-6 py-2.5 text-xs font-medium uppercase leading-normal text-white shadow-md transition duration-150 ease-in-out hover:shadow-lg focus:shadow-lg focus:outline-none focus:ring-0 active:shadow-lg"
       style="background-color: #0088cc">
-      <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-      <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
       <svg
         class="h-4 w-4"
         fill="currentColor"
@@ -1795,8 +1785,6 @@ menu:
           data-te-ripple-color="light"
           class="mb-2 inline-block rounded px-6 py-2.5 text-xs font-medium uppercase leading-normal text-white shadow-md transition duration-150 ease-in-out hover:shadow-lg focus:shadow-lg focus:outline-none focus:ring-0 active:shadow-lg"
           style="background-color: #0088cc">
-          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-          <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
           <svg
             class="h-4 w-4"
             fill="currentColor"


### PR DESCRIPTION
Looks like this one example for Telegram had some extra text pasted in that was causing errors for me.

Hope this helps!