### PR TITLE
component image name corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ Collection of free, popular components like modal, dropdown, carousel, popover, 
     </td>
   </tr>
   <tr>
-    <td align="center"><b>Accordion</b></td>
-    <td align="center"><b>Tabs</b></td>
-    <td align="center"><b>Stepper</b></td>
+    <td align="center"><b>Timepicker</b></td>
+    <td align="center"><b>Footer</b></td>
+    <td align="center"><b>Navbar</b></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Corrected the names of last row images in the **component section** table. 
 
![mdbootstrap-Tailwind-Elements-The-most-popular-independent-Tailwind-library-𝙃𝙪𝙜𝙚-collection-of-Tailwind-components-sections-and-templates-😎](https://user-images.githubusercontent.com/99909551/221344094-27f61a1f-d365-4574-ba32-99b8667091cd.png)
