### PR TITLE
Fixed input style incorrect with autofocus attribute

### DIFF
--- a/src/js/forms/input.js
+++ b/src/js/forms/input.js
@@ -519,7 +519,7 @@ class Input {
         this._element
       );
 
-      if (event && event.type === "focus") {
+      if ((event && event.type === "focus") || input.autofocus) {
         notchWrapper.setAttribute(DATA_FOCUSED, "");
       }
 


### PR DESCRIPTION
Input component not correctly initilalized on document loaded with autofocus attribute has setted.

![image](https://github.com/mdbootstrap/Tailwind-Elements/assets/14287603/b6bedc38-4ebc-4e70-b1b8-ad6fe9218666)