### PR TITLE
Update calculation of element offsets

### DIFF
--- a/src/js/dom/manipulator.js
+++ b/src/js/dom/manipulator.js
@@ -96,8 +96,8 @@ const Manipulator = {
     const rect = element.getBoundingClientRect();
 
     return {
-      top: rect.top + Math.max(document.body.scrollTop, document.documentElement.scrollTop, window.scrollY),
-      left: rect.left + Math.max(document.body.scrollLeft, document.documentElement.scrollLeft, window.scrollX),
+      top: rect.top + document.body.scrollTop,
+      left: rect.left + document.body.scrollLeft,
     };
   },
 
@@ -150,6 +150,27 @@ const Manipulator = {
 
   hasClass(element, className) {
     return element.classList.contains(className);
+  },
+
+  maxOffset(element) {
+    const rect = element.getBoundingClientRect();
+
+    return {
+      top:
+        rect.top +
+        Math.max(
+          document.body.scrollTop,
+          document.documentElement.scrollTop,
+          window.scrollY
+        ),
+      left:
+        rect.left +
+        Math.max(
+          document.body.scrollLeft,
+          document.documentElement.scrollLeft,
+          window.scrollX
+        ),
+    };
   },
 };
 

--- a/src/js/dom/manipulator.js
+++ b/src/js/dom/manipulator.js
@@ -96,8 +96,8 @@ const Manipulator = {
     const rect = element.getBoundingClientRect();
 
     return {
-      top: rect.top + document.body.scrollTop,
-      left: rect.left + document.body.scrollLeft,
+      top: rect.top + Math.max(document.body.scrollTop, document.documentElement.scrollTop, window.scrollY),
+      left: rect.left + Math.max(document.body.scrollLeft, document.documentElement.scrollLeft, window.scrollX),
     };
   },
 

--- a/src/js/navigation/scrollspy.js
+++ b/src/js/navigation/scrollspy.js
@@ -67,7 +67,7 @@ const SELECTOR_LINK_ITEMS = `${SELECTOR_NAV_LINKS}, ${SELECTOR_LIST_ITEMS}, ${SE
 const SELECTOR_DROPDOWN = "[data-te-dropdown-ref]";
 const SELECTOR_DROPDOWN_TOGGLE = "[data-te-dropdown-toggle-ref]";
 
-const METHOD_OFFSET = "offset";
+const METHOD_OFFSET = "maxOffset";
 const METHOD_POSITION = "position";
 
 /*


### PR DESCRIPTION
Change the way element top/left offsets are computed, from using document.body scroll attributes (scrollTop and scrollLeft) to get scroll position, to using document.documentElement scroll attributes.
This is because document.body scroll attributes always return zero unless the body has a fixed height and overflow set to auto/scroll [as explained here](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop).
document.documentElement scroll attributes resolve to scroll attributes of the window [as explained here](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop#:~:text=When%20scrollTop%20is%20used%20on%20the%20root%20element%20(the%20%3Chtml%3E%20element)%2C%20the%20scrollY%20of%20the%20window%20is%20returned.%20This%20is%20a%20special%20case%20of%20scrollTop).
fixes #1738 