### PR TITLE
Fix issue #1852: Hide placeholder text by default and show on focus

### DIFF
--- a/site/content/angular/index.html
+++ b/site/content/angular/index.html
@@ -17,6 +17,15 @@ menu:
 ---
 
 <!-- Section: Intro -->
+<script src="https://cdn.tailwindcss.com"></script>
+<script>function showPlaceholder(input) {
+  input.placeholder = "Enter your email";
+}
+
+function hidePlaceholder(input) {
+  input.placeholder = "";
+}
+</script>
 <section
   class="mx-auto mb-[64px] mt-24 pb-[64px] min-[576px]:max-w-[540px] min-[768px]:max-w-[720px] min-[992px]:max-w-[960px] min-[1200px]:max-w-[1140px] min-[1400px]:max-w-[1320px]">
   <div class="grid grid-cols-1 items-center pt-6 lg:grid-cols-12">
@@ -154,13 +163,18 @@ menu:
                   class="relative w-full max-w-[400px]"
                   data-te-input-wrapper-init>
                   <input
-                    type="email"
-                    required=""
-                    id="email"
-                    name="email_address"
-                    placeholder="Enter your email"
-                    class="peer block min-h-[auto] w-full rounded border-0 bg-transparent px-3 py-[0.32rem] leading-[1.6] outline-none transition-all duration-200 ease-linear focus:placeholder:opacity-100 data-[te-input-state-active]:placeholder:opacity-100 motion-reduce:transition-none dark:text-gray-200 dark:placeholder:text-gray-200 [&:not([data-te-input-placeholder-active])]:placeholder:opacity-0"
-                    required />
+                  type="email"
+                  required=""
+                  id="email"
+                  name="email_address"
+                  placeholder=""
+                  class="peer block min-h-[auto] w-full rounded border-0 bg-transparent px-3 py-[0.32rem] leading-[1.6] outline-none focus:placeholder-opacity-100 motion-reduce:transition-none dark:text-gray-200 dark:placeholder-text-gray-200 [&:not([data-te-input-placeholder-active])]:placeholder-opacity-0"
+                  required
+                  onfocus="showPlaceholder(this)"
+                  onblur="hidePlaceholder(this)"
+                />
+                
+                <label
                   <label
                     for="tailwind-updates-form"
                     class="pointer-events-none absolute left-3 top-0 mb-0 max-w-[90%] origin-[0_0] truncate pt-[0.37rem] leading-[1.6] text-gray-500 transition-all duration-200 ease-out peer-focus:-translate-y-[0.9rem] peer-focus:scale-[0.8] peer-focus:text-blue-600 peer-data-[te-input-state-active]:-translate-y-[0.9rem] peer-data-[te-input-state-active]:scale-[0.8] motion-reduce:transition-none dark:text-gray-200 dark:peer-focus:text-gray-200">
@@ -208,4 +222,5 @@ menu:
     </div>
   </div>
 </section>
+
 <!-- Section: Intro -->

--- a/site/content/angular/index.html
+++ b/site/content/angular/index.html
@@ -17,7 +17,6 @@ menu:
 ---
 
 <!-- Section: Intro -->
-<script src="https://cdn.tailwindcss.com"></script>
 <script>function showPlaceholder(input) {
   input.placeholder = "Enter your email";
 }


### PR DESCRIPTION
This commit addresses the issue where the placeholder text was always visible in the input field. The placeholder text is now hidden by default and will only appear when the input field is focused. The JavaScript functions have been added to control the visibility of the placeholder text based on the input's focus state. This enhances the user experience by providing a cleaner and more intuitive input interaction.
Transition Error Page
https://tailwind-elements.com/angular/